### PR TITLE
Two corrections in the '1.1. Beyond JPA' paragraph.

### DIFF
--- a/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
+++ b/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
@@ -99,7 +99,7 @@ Optional<Deity> nameResult = repository.findByName("Diana");
 JPA is a good API for object-relational mapping and has established itself as a standard in the Java world defined in JSRs. It would be ideal to use the same API for both SQL and NoSQL, but there are behaviors in NoSQL that SQL does not cover, such as time to live and asynchronous operations. JPA was simply not designed to handle those features.
 
 
-[source,java]
+[source,java,subs="quotes"]
 ----
 ColumnTemplate template = //instance;
 Deity diana = Deity.builder()
@@ -107,8 +107,8 @@ Deity diana = Deity.builder()
         .withName("Diana")
         .withPower("hunt")
         .builder();
-Duration ttl = Duration.ofSeconds(1);
-template.insert(diana, Duration.ofSeconds(1));
+*Duration ttl = Duration.ofSeconds(1);*
+template.insert(diana, *ttl*);
 ----
 
 


### PR DESCRIPTION
Hello Team,

this PR is about source code improving within '1.1. Beyond JPA' paragraph:

*************************
ColumnTemplate template = …;

Deity diana = Deity.builder().withId("diana").withName("Diana").withPower("hunt").builder();

_Duration ttl = Duration.ofSeconds(1);_

template.insert(diana, _Duration.ofSeconds(1)_);

*************************
we have the declaration of "**ttl**" variable that is not used in "**template.insert**" method call, and instead of "**ttl**" there is "**Duration.ofSeconds(1)**" another time.

I've corrected the code as follows:

*************************
ColumnTemplate template = …;

Deity diana = Deity.builder().withId("diana").withName("Diana").withPower("hunt").builder();

**Duration ttl = Duration.ofSeconds(1);**

template.insert(diana, **ttl**);

*************************
Also the declaration of "ttl" and parameter "ttl" are highlighted as bold now.

Thank you very much,
Dmitri.