### PR TITLE
Modify TypeReferenceReaderDecorator and ValueReaderDecorator to use ServiceLoaderProvider for service location

### DIFF
--- a/api/communication/communication-core/src/main/java/jakarta/nosql/TypeReferenceReaderDecorator.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/TypeReferenceReaderDecorator.java
@@ -19,7 +19,6 @@ package jakarta.nosql;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
 
 /**
  * Decorators of all {@link TypeReferenceReader} supported by Jakarta NoSQL
@@ -33,7 +32,9 @@ public final class TypeReferenceReaderDecorator implements TypeReferenceReader {
     private final List<TypeReferenceReader> readers = new ArrayList<>();
 
     {
-        ServiceLoader.load(TypeReferenceReader.class).forEach(readers::add);
+        ServiceLoaderProvider.getSupplierStream(TypeReferenceReader.class)
+            .map(TypeReferenceReader.class::cast)
+            .forEach(readers::add);
     }
 
     public static TypeReferenceReaderDecorator getInstance() {

--- a/api/communication/communication-core/src/main/java/jakarta/nosql/ValueReaderDecorator.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/ValueReaderDecorator.java
@@ -19,7 +19,6 @@ package jakarta.nosql;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
 
 /**
  * Decorators of all {@link ValueReader} supported by Jakarta NoSQL
@@ -32,7 +31,9 @@ public final class ValueReaderDecorator implements ValueReader {
     private final List<ValueReader> readers = new ArrayList<>();
 
     {
-        ServiceLoader.load(ValueReader.class).forEach(readers::add);
+        ServiceLoaderProvider.getSupplierStream(ValueReader.class)
+            .map(ValueReader.class::cast)
+            .forEach(readers::add);
     }
 
     public static ValueReaderDecorator getInstance() {


### PR DESCRIPTION
This PR isn't strictly related to my others, though it's useful in the same situation where I use the ServiceLoader change. This one is targeted at just making it so that these two classes use the same ServiceLoaderProvider mechanism to retrieve services as other components do.