### PR TITLE
Document CriteriaQuery API

### DIFF
--- a/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/Attribute.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/Attribute.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.metamodel;
+
+/**
+ * Represents an attribute of a JNoSql Entity type
+ * @param <X> The Entity type the attribute belongs to
+ * @param <Y> The attribute type
+ */
+public interface Attribute<X extends Object, Y extends Object> {
+    
+    /**
+     * Return the name of the attribute
+     * @return the name of the attribute
+    */
+    public String getName();
+    
+}

--- a/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/ComparableAttribute.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/ComparableAttribute.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.metamodel;
+
+/**
+ * Represents a singular comparable attribute of a JNoSql Entity type
+ * @param <X> The Entity type the comparable attribute belongs to
+ * @param <Y> The attribute type
+*/
+public interface ComparableAttribute<X extends Object, Y extends Comparable> extends SingularAttribute<X, Y> {
+    
+}

--- a/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/PluralAttribute.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/PluralAttribute.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.metamodel;
+
+/**
+ * Represents a plural attribute of a JNoSql Entity type
+ * @param <X> The Entity type the plural attribute belongs to
+ * @param <T> The attribute type
+*/
+public interface PluralAttribute<X extends Object, T extends Object> extends Attribute<X, T> {
+    
+}

--- a/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/SingularAttribute.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/SingularAttribute.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.metamodel;
+
+/**
+ * Represents a singular attribute of a JNoSql Entity type
+ *
+ * @param <X> The Entity type the singular attribute belongs to
+ * @param <T> The attribute type
+ */
+public interface SingularAttribute<X extends Object, T extends Object> extends Attribute<X, T> {
+
+    /**
+     * Return the type that represents the type of the attribute
+     * 
+     * @return type of attribute
+     */
+    public Class<T> getType();
+
+}

--- a/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/StringAttribute.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/metamodel/StringAttribute.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.metamodel;
+
+/**
+ * Represents a singular string attribute of a JNoSql Entity type
+ * @param <X> The Entity type the string attribute belongs to
+*/
+public interface StringAttribute<X extends Object> extends SingularAttribute<X, String> {
+    
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/ComparableExpression.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/ComparableExpression.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * Type for query expressions representing a comparable Entity attribute
+ *
+ * @param <X> the entity type
+ * @param <T> the comparable type of the expression
+ */
+public interface ComparableExpression<X extends Object, T extends Comparable> extends Expression<X, T> {
+
+    /**
+     * Create a predicate for testing whether this expression is greater than
+     * the argument expression
+     *
+     * @param <Y> the comparable type or subtype
+     * @param expression expression
+     * @return greater-than predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> greaterThan(Expression<X, ? extends Y> expression);
+
+    /**
+     * Create a predicate for testing whether this expression is greater than
+     * the argument value
+     *
+     * @param <Y> the comparable type or subtype
+     * @param y value
+     * @return greater-than predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> greaterThan(Y y);
+
+    /**
+     * Create a predicate for testing whether this expression is greater than or
+     * equal to the argument expression
+     *
+     * @param <Y> the comparable type or subtype
+     * @param expression expression
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> greaterThanOrEqualTo(Expression<X, ? extends Y> expression);
+
+    /**
+     * Create a predicate for testing whether this expression is greater than or
+     * equal to the argument value
+     *
+     * @param <Y> the comparable type or subtype
+     * @param y value
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> greaterThanOrEqualTo(Y y);
+
+    /**
+     * Create a predicate for testing whether this expression is less than the
+     * argument expression
+     *
+     * @param <Y> the comparable type or subtype
+     * @param expression expression
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> lessThan(Expression<X, ? extends Y> expression);
+
+    /**
+     * Create a predicate for testing whether this expression is less than the
+     * argument value
+     *
+     * @param <Y> the comparable type or subtype
+     * @param y value
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> lessThan(Y y);
+
+    /**
+     * Create a predicate for testing whether this expression is less than or
+     * equal to the argument expression
+     *
+     * @param <Y> the comparable type or subtype
+     * @param expression expression
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> lessThanOrEqualTo(Expression<X, ? extends Y> expression);
+
+    /**
+     * Create a predicate for testing whether this expression is less than or
+     * equal to the argument value
+     *
+     * @param <Y> the comparable type or subtype
+     * @param y value
+     * @return greater-than-or-equal predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> lessThanOrEqualTo(Y y);
+
+    /**
+     * Create a predicate for testing whether the this expression is between the
+     * first and second argument expressions in value
+     *
+     * @param <Y> the comparable type or subtype
+     * @param exprsn1 expression
+     * @param exprsn2 expression
+     * @return between predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> between(Expression<X, ? extends Y> exprsn1, Expression<X, ? extends Y> exprsn2);
+
+    /**
+     * Create a predicate for testing whether the this expression value is
+     * between the first and second argument values
+     *
+     * @param <Y> the comparable type or subtype
+     * @param x value
+     * @param y value
+     * @return between predicate
+     */
+    public <Y extends Comparable<? super Y>> Predicate<X> between(Y x, Y y);
+
+    /**
+     * Create an ordering by the ascending value of this expression
+     *
+     * @param <T> the comparable type
+     * @return ascending ordering corresponding to the expression
+     */
+    public <T extends Object> Order<T> asc();
+
+    /**
+     * Create an ordering by the descending value of the expression
+     *
+     * @param <T> the comparable type
+     * @return descending ordering corresponding to the expression
+     */
+    public <T extends Object> Order<T> desc();
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/CompositionPredicate.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/CompositionPredicate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+import java.util.Collection;
+
+/**
+ * Composition of {@link Predicate}s
+ *
+ * @param <T> The Entity type whose fetching is to be be restricted
+ */
+public interface CompositionPredicate<T extends Object> extends Predicate<T> {
+
+    /**
+     * Return the composed {@link Predicate}s.
+     *
+     * @return collection of predicates
+     */
+    Collection<Predicate<T>> getPredicates();
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/ConjunctionPredicate.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/ConjunctionPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * Conjunction of {@link Predicate}s
+ *
+ * @param <T> The Entity type whose fetching is to be be restricted
+ */
+public interface ConjunctionPredicate<T extends Object> extends CompositionPredicate<T> {
+    
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/CriteriaQuery.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/CriteriaQuery.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The <code>CriteriaQuery</code> interface defines functionality that is
+ * specific to top-level queries.
+ *
+ * @param <T> the type of the defined result
+ */
+public interface CriteriaQuery<T extends Object> {
+
+    /**
+     * Returns the from clause to be restricted
+     *
+     * @return from clause
+     */
+    public Root<T> getRoot();
+
+    /**
+     * Modify the query to restrict the query result according to the
+     * conjunction of the specified restriction predicates. Replaces the
+     * previously added restriction(s), if any.
+     *
+     * @param restrictions zero or more restriction predicates
+     * @return the modified query
+     */
+    public CriteriaQuery<T> where(Collection<Predicate<T>> restrictions);
+
+    /**
+     * Specify the ordering expressions that are used to order the query
+     * results. Replaces the previous ordering expressions, if any. The
+     * left-to-right sequence of the ordering expressions determines the
+     * precedence, whereby the leftmost has highest precedence.
+     *
+     * @param o zero or more ordering expressions
+     * @return the modified query
+     */
+    public CriteriaQuery<T> orderBy(List<Order<T>> o);
+
+    /**
+     * Set the maximum number of results to retrieve.
+     *
+     * @param maxResult maximum number of results to retrieve
+     * @return the same query instance
+     * @throws IllegalArgumentException if the argument is negative
+     */
+    public CriteriaQuery<T> setMaxResults(int maxResult);
+
+    /**
+     * Set the position of the first result to retrieve.
+     *
+     * @param startPosition position of the first result, numbered from 0
+     * @return the same query instance
+     * @throws IllegalArgumentException if the argument is negative
+     */
+    public CriteriaQuery<T> setFirstResult(int startPosition);
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/DisjunctionPredicate.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/DisjunctionPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * Disjunction of {@link Predicate}s
+ *
+ * @param <T> The Entity type whose fetching is to be be restricted
+ */
+public interface DisjunctionPredicate<T extends Object> extends CompositionPredicate<T> {
+    
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Expression.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Expression.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+import java.util.Collection;
+
+/**
+ * Type for query expressions representing an Entity attribute
+ *
+ * @param <X> the entity type
+ * @param <T> the type of the expression
+ */
+public interface Expression<X extends Object, T extends Object> {
+
+    /**
+     * Create a predicate for testing if the expression is equal to the argument
+     * expression
+     *
+     * @param expression the expression to check the equality against
+     * @return equality predicate
+     */
+    public Predicate<X> equal(Expression<X, T> expression);
+
+    /**
+     * Create a predicate for testing if the expression is equal to the argument
+     * value
+     *
+     * @param value the value to check the equality against
+     * @return equality predicate
+     */
+    public Predicate<X> equal(T value);
+
+    /**
+     * Create a predicate to test whether the expression is a member of the
+     * argument list.
+     *
+     * @param values values to be tested against
+     * @return predicate testing for membership
+     */
+    public Predicate<X> in(Collection<T> values);
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/NegationPredicate.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/NegationPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * Negation of a {@link Predicate}
+ *
+ * @param <T> The Entity type whose fetching is to be be restricted
+ */
+public interface NegationPredicate<T extends Object> extends Predicate<T> {
+
+    /**
+     * Return the negated {@link Predicate}.
+     *
+     * @return negated predicate
+     */
+    Predicate<T> getPredicate();
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Order.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Order.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+import jakarta.nosql.metamodel.ComparableAttribute;
+
+/**
+ * An object that defines an ordering over the query results
+ *
+ * @param <T> the type of the defined result
+ */
+public interface Order<T> {
+
+    /**
+     * Whether ascending ordering is in effect
+     *
+     * @return boolean indicating whether ordering is ascending
+     */
+    public boolean isAscending();
+
+    /**
+     * Return the expression that is used for ordering
+     *
+     * @return expression used for ordering
+     */
+    public ComparableAttribute<T, ?> getAttribute();
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Predicate.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Predicate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * A predicate representing a restriction in a {@link CriteriaQuery}
+ *
+ * @param <T> The Entity type whose fetching is to be be restricted
+ */
+public interface Predicate<T extends Object> {
+
+    /**
+     * Create a negation of this restriction.
+     *
+     * @return not predicate
+     */
+    public NegationPredicate<T> not();
+
+    /**
+     * Create a conjunction of this with the argument restriction
+     *
+     * @param restriction restriction
+     * @return and predicate
+     */
+    public ConjunctionPredicate<T> and(Predicate<T> restriction);
+
+    /**
+     * Create a disjunction of this with the argument restriction
+     *
+     * @param restriction restriction
+     * @return or predicate
+     */
+    public DisjunctionPredicate<T> or(Predicate<T> restriction);
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Root.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/Root.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+import jakarta.nosql.metamodel.ComparableAttribute;
+import jakarta.nosql.metamodel.SingularAttribute;
+import jakarta.nosql.metamodel.StringAttribute;
+
+/**
+ * The Entity type representing the from clause of a {@link CriteriaQuery}
+ *
+ * @param <X> the entity type referenced by the root
+ */
+public interface Root<X extends Object> {
+
+    /**
+     * Create an expression corresponding to the referenced single-valued
+     * attribute
+     *
+     * @param <Y> the type of the attribute
+     * @param attribute single-valued attribute
+     * @return expression corresponding to the referenced attribute
+     */
+    public <Y extends Object> Expression<X, Y> get(SingularAttribute<? super X, Y> attribute);
+
+    /**
+     * Create an expression corresponding to the referenced single-valued string
+     * attribute
+     *
+     * @param attribute single-valued string attribute
+     * @return string expression corresponding to the referenced string
+     * attribute
+     */
+    public StringExpression<X> get(StringAttribute<? extends X> attribute);
+
+    /**
+     * Create an expression corresponding to the referenced single-valued
+     * comparable attribute
+     *
+     * @param <Y> the type of the comparable attribute
+     * @param attribute single-valued comparable attribute
+     * @return comparable expression corresponding to the referenced comparable
+     * attribute
+     */
+    public <Y extends Comparable> ComparableExpression<X, Y> get(ComparableAttribute<? super X, Y> attribute);
+
+}

--- a/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/StringExpression.java
+++ b/api/communication/communication-query/src/main/java/jakarta/nosql/criteria/StringExpression.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Otavio Santana and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
+ */
+package jakarta.nosql.criteria;
+
+/**
+ * Type for query expressions representing a string Entity attribute
+ *
+ * @param <X> the entity type
+ */
+public interface StringExpression<X extends Object> extends Expression<X, String> {
+
+    /**
+     * Create a predicate for testing whether this expression satisfies the
+     * given pattern
+     *
+     * @param pattern string
+     * @return like predicate
+     */
+    public Predicate<X> like(String pattern);
+
+}

--- a/api/mapping/mapping-document/src/main/java/jakarta/nosql/mapping/document/DocumentTemplate.java
+++ b/api/mapping/mapping-document/src/main/java/jakarta/nosql/mapping/document/DocumentTemplate.java
@@ -12,11 +12,16 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *     Alessandro Moscatelli
+ *
  */
 package jakarta.nosql.mapping.document;
 
 
 import jakarta.nosql.NonUniqueResultException;
+import jakarta.nosql.criteria.CriteriaQuery;
 import jakarta.nosql.document.DocumentDeleteQuery;
 import jakarta.nosql.document.DocumentQuery;
 import jakarta.nosql.mapping.Page;
@@ -34,6 +39,16 @@ import java.util.stream.Stream;
  * @see jakarta.nosql.document.DocumentCollectionManager
  */
 public interface DocumentTemplate extends Template {
+
+    /**
+     * Create a <code>CriteriaQuery</code> object with the specified result
+     * type.
+     *
+     * @param <T> type of the query result
+     * @param type type of the query result
+     * @return criteria query object
+     */
+    public <T extends Object> CriteriaQuery<T> createQuery(Class<T> type);
 
 
     /**
@@ -53,6 +68,16 @@ public interface DocumentTemplate extends Template {
      * @throws NullPointerException when query is null
      */
     <T> Stream<T> select(DocumentQuery query);
+
+    /**
+     * Finds entities from criteriaquery
+     *
+     * @param criteriaQuery - query to figure out entities
+     * @param <T>   the instance type
+     * @return entities found by query
+     * @throws NullPointerException when criteriaQuery is null
+     */
+    <T> Stream<T> select(CriteriaQuery criteriaQuery);
 
     /**
      * Finds entities from query using pagination
@@ -84,6 +109,17 @@ public interface DocumentTemplate extends Template {
      * @throws UnsupportedOperationException when the database dot not have support
      */
     <T> long count(Class<T> entityType);
+
+    /**
+     * Returns the number of elements from column family using a
+     * {@link CriteriaQuery}
+     *
+     * @param criteriaQuery - query to figure out entities
+     * @param <T> the instance type
+     * @return the number of elements
+     * @throws NullPointerException when criteriaQuery is null
+     */
+    <T> long count(CriteriaQuery criteriaQuery);
 
     /**
      * Returns a single entity from query


### PR DESCRIPTION
As described in https://github.com/eclipse/jnosql/issues/263

I selected a first subset of JPA functionalities (the ones regarding the CriteriaQuery API).
This will allow a JPA style hierarchical and strongly typed query system based on predicates on Entity Metadata

UpdateQuery and DeleteQuery will be released in other pull requests.