### PR TITLE
Modify ServiceLoaderProvider to use the HK2 OSGi ServiceLoader when present

### DIFF
--- a/api/communication/communication-core/src/main/java/jakarta/nosql/ServiceLoaderProvider.java
+++ b/api/communication/communication-core/src/main/java/jakarta/nosql/ServiceLoaderProvider.java
@@ -55,7 +55,7 @@ public final class ServiceLoaderProvider {
 
     /**
      * Searches implementation using {@link ServiceLoader}, and it will return the higher priority
-     * {@link jakarta.annotation.Priority}
+     * {@link javax.annotation.Priority}
      *
      * @param supplier the class
      * @param <T>      the type


### PR DESCRIPTION
This PR modifies ServiceLoaderProvider to pick up on the presence of the HK2 ServiceLoader implementation in the current classpath, using that instead of a direct `ServiceLoader.load` call. This allows it to pick up provider classes in a basic way in an OSGi context, while not changing the effective behavior or API outside of OSGi.

This is a non-contaminated version of https://github.com/eclipse-ee4j/nosql/pull/84