### PR TITLE
Add a new no method to negate conditions

### DIFF
--- a/api/communication/communication-column/src/main/java/jakarta/nosql/column/ColumnCondition.java
+++ b/api/communication/communication-column/src/main/java/jakarta/nosql/column/ColumnCondition.java
@@ -86,7 +86,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#eq(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#EQUALS}
      * @throws NullPointerException when either name or value is null
@@ -113,7 +114,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#gt(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#GREATER_THAN}
      * @throws NullPointerException when either name or value is null
@@ -124,6 +126,7 @@ public interface ColumnCondition {
         return ServiceLoaderProvider.get(ColumnConditionProvider.class)
                 .apply(Column.of(name, value), Condition.GREATER_THAN);
     }
+
     /**
      * Creates a {@link ColumnCondition} that has a {@link Condition#GREATER_EQUALS_THAN},
      * it means a select will scanning to a column family that has the same name and the value
@@ -140,7 +143,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#gte(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#GREATER_EQUALS_THAN}
      * @throws NullPointerException when either name or value is null
@@ -167,7 +171,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#lt(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#LESSER_THAN}
      * @throws NullPointerException when either name or value is null
@@ -195,7 +200,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#lte(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#LESSER_EQUALS_THAN}
      * @throws NullPointerException when either name or value is null
@@ -223,7 +229,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#in(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#IN}
      * @throws NullPointerException when either name or value is null
@@ -250,7 +257,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#like(Column)} where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#LIKE}
      * @throws NullPointerException when either name or value is null
@@ -282,7 +290,8 @@ public interface ColumnCondition {
     /**
      * an alias method to {@link ColumnCondition#between(Column)} (Column) where it will create a {@link Column}
      * instance first and then apply te condition.
-     * @param name the name of the column
+     *
+     * @param name  the name of the column
      * @param value the column information
      * @return a {@link ColumnCondition} with {@link Condition#BETWEEN}
      * @throws NullPointerException when either name or value is null
@@ -294,6 +303,18 @@ public interface ColumnCondition {
                 .between(Column.of(name, value));
     }
 
+    /**
+     * Returns a predicate that is the negation of the supplied predicate.
+     * This is accomplished by returning result of the calling target.negate().
+     *
+     * @param condition
+     * @return a condition that negates the results of the supplied predicate
+     * @throws NullPointerException when condition is null
+     */
+    static ColumnCondition not(ColumnCondition condition) {
+        Objects.requireNonNull(condition, "condition is required");
+        return condition.negate();
+    }
 
     /**
      * Returns a new {@link ColumnCondition} aggregating ,as "AND", all the conditions as just one condition.
@@ -345,6 +366,7 @@ public interface ColumnCondition {
 
         /**
          * Creates a {@link Condition#BETWEEN} operation
+         *
          * @param column the column
          * @return a {@link ColumnCondition}
          */
@@ -352,6 +374,7 @@ public interface ColumnCondition {
 
         /**
          * Creates a {@link Condition#AND} operation
+         *
          * @param conditions the conditions
          * @return a {@link ColumnCondition}
          */
@@ -359,6 +382,7 @@ public interface ColumnCondition {
 
         /**
          * Creates a {@link Condition#OR} operation
+         *
          * @param conditions the conditions
          * @return a {@link ColumnCondition}
          */
@@ -366,6 +390,7 @@ public interface ColumnCondition {
 
         /**
          * Creates a {@link Condition#IN} operation
+         *
          * @param column the column
          * @return a {@link ColumnCondition}
          */

--- a/api/communication/communication-document/src/main/java/jakarta/nosql/document/DocumentCondition.java
+++ b/api/communication/communication-document/src/main/java/jakarta/nosql/document/DocumentCondition.java
@@ -281,6 +281,19 @@ public interface DocumentCondition {
     }
 
     /**
+     * Returns a predicate that is the negation of the supplied predicate.
+     * This is accomplished by returning result of the calling target.negate().
+     *
+     * @param condition
+     * @return a condition that negates the results of the supplied predicate
+     * @throws NullPointerException when condition is null
+     */
+    static DocumentCondition not(DocumentCondition condition) {
+        Objects.requireNonNull(condition, "condition is required");
+        return condition.negate();
+    }
+
+    /**
      * an alias method to {@link DocumentCondition#between(Document)} where it will create a {@link Document}
      * instance first and then apply te condition.
      * @param name the name of the document

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
@@ -62,10 +62,10 @@ public class ColumnConditionTest {
         Column age = Column.of("age", 26);
         ColumnCondition condition = ColumnCondition.gt(age);
         ColumnCondition negate = condition.negate();
-        Column negateDocument = negate.getColumn();
+        Column negateColumn = negate.getColumn();
         assertEquals(Condition.NOT, negate.getCondition());
-        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
-        assertEquals(ColumnCondition.gt(age), negateDocument.getValue().get());
+        assertEquals(Condition.NOT.getNameField(), negateColumn.getName());
+        assertEquals(ColumnCondition.gt(age), negateColumn.getValue().get());
     }
 
     @Test
@@ -81,10 +81,10 @@ public class ColumnConditionTest {
         Column age = Column.of("age", 26);
         ColumnCondition condition = ColumnCondition.gt(age);
         ColumnCondition negate = ColumnCondition.not(condition);
-        Column negateDocument = negate.getColumn();
+        Column negateColumn = negate.getColumn();
         assertEquals(Condition.NOT, negate.getCondition());
-        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
-        assertEquals(ColumnCondition.gt(age), negateDocument.getValue().get());
+        assertEquals(Condition.NOT.getNameField(), negateColumn.getName());
+        assertEquals(ColumnCondition.gt(age), negateColumn.getValue().get());
     }
 
     @Test

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
@@ -76,6 +76,30 @@ public class ColumnConditionTest {
         Assertions.assertEquals(condition, affirmative);
     }
 
+    @Test
+    public void shouldCreateNotCondition() {
+        Column age = Column.of("age", 26);
+        ColumnCondition condition = ColumnCondition.gt(age);
+        ColumnCondition negate = ColumnCondition.not(condition);
+        Column negateDocument = negate.getColumn();
+        assertEquals(Condition.NOT, negate.getCondition());
+        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
+        assertEquals(ColumnCondition.gt(age), negateDocument.getValue().get());
+    }
+
+    @Test
+    public void shouldReturnValidDoubleNot() {
+        Column age = Column.of("age", 26);
+        ColumnCondition condition = ColumnCondition.gt(age);
+        ColumnCondition affirmative = ColumnCondition.not(ColumnCondition.not(condition));
+        Assertions.assertEquals(condition, affirmative);
+    }
+
+    @Test
+    public void shouldShouldReturnErrorOnNot() {
+        Assertions.assertThrows(NullPointerException.class, ()-> ColumnCondition.not(null));
+    }
+
 
     @Test
     public void shouldReturnNPEInGtWhenParameterIsNull() {

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ColumnConditionTest {
 
     @Test
@@ -54,6 +56,26 @@ public class ColumnConditionTest {
         Assertions.assertEquals(Condition.EQUALS, condition.getCondition());
         Assertions.assertEquals(column, condition.getColumn());
     }
+
+    @Test
+    public void shouldCreateNegationCondition() {
+        Column age = Column.of("age", 26);
+        ColumnCondition condition = ColumnCondition.gt(age);
+        ColumnCondition negate = condition.negate();
+        Column negateDocument = negate.getColumn();
+        assertEquals(Condition.NOT, negate.getCondition());
+        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
+        assertEquals(ColumnCondition.gt(age), negateDocument.getValue().get());
+    }
+
+    @Test
+    public void shouldReturnValidDoubleNegation() {
+        Column age = Column.of("age", 26);
+        ColumnCondition condition = ColumnCondition.gt(age);
+        ColumnCondition affirmative = condition.negate().negate();
+        Assertions.assertEquals(condition, affirmative);
+    }
+
 
     @Test
     public void shouldReturnNPEInGtWhenParameterIsNull() {

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
@@ -66,6 +66,7 @@ public class DocumentConditionTest {
         DocumentCondition affirmative = condition.negate().negate();
         Assertions.assertEquals(condition, affirmative);
     }
+
     @Test
     public void shouldCreateEqFromNameValue() {
         Document document = Document.of("name", "Ada Lovelace");

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
@@ -67,6 +67,31 @@ public class DocumentConditionTest {
         Assertions.assertEquals(condition, affirmative);
     }
 
+
+    @Test
+    public void shouldCreateNotCondition() {
+        Document age = Document.of("age", 26);
+        DocumentCondition condition = DocumentCondition.gt(age);
+        DocumentCondition negate = DocumentCondition.not(condition);
+        Document negateDocument = negate.getDocument();
+        assertEquals(Condition.NOT, negate.getCondition());
+        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
+        assertEquals(DocumentCondition.gt(age), negateDocument.getValue().get());
+    }
+
+    @Test
+    public void shouldReturnValidDoubleNot() {
+        Document age = Document.of("age", 26);
+        DocumentCondition condition = DocumentCondition.gt(age);
+        DocumentCondition affirmative = DocumentCondition.not(DocumentCondition.not(condition));
+        Assertions.assertEquals(condition, affirmative);
+    }
+
+    @Test
+    public void shouldShouldReturnErrorOnNot() {
+        Assertions.assertThrows(NullPointerException.class, ()-> DocumentCondition.not(null));
+    }
+
     @Test
     public void shouldCreateEqFromNameValue() {
         Document document = Document.of("name", "Ada Lovelace");

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class DocumentConditionTest {
 
     @Test
@@ -46,6 +48,24 @@ public class DocumentConditionTest {
         Assertions.assertEquals(document, condition.getDocument());
     }
 
+    @Test
+    public void shouldCreateNegationCondition() {
+        Document age = Document.of("age", 26);
+        DocumentCondition condition = DocumentCondition.gt(age);
+        DocumentCondition negate = condition.negate();
+        Document negateDocument = negate.getDocument();
+        assertEquals(Condition.NOT, negate.getCondition());
+        assertEquals(Condition.NOT.getNameField(), negateDocument.getName());
+        assertEquals(DocumentCondition.gt(age), negateDocument.getValue().get());
+    }
+
+    @Test
+    public void shouldReturnValidDoubleNegation() {
+        Document age = Document.of("age", 26);
+        DocumentCondition condition = DocumentCondition.gt(age);
+        DocumentCondition affirmative = condition.negate().negate();
+        Assertions.assertEquals(condition, affirmative);
+    }
     @Test
     public void shouldCreateEqFromNameValue() {
         Document document = Document.of("name", "Ada Lovelace");


### PR DESCRIPTION
This PR adds a new method: the static method ```no```
It will call the ```negate``` method.

this method follows the exact nomenclature of the JDK at the [Predicate](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/function/Predicate.html) interface:

- [negate](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/function/Predicate.html#negate())
- [no](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/function/Predicate.html#not(java.util.function.Predicate))