### PR TITLE
Add <sourceDirectory> tag to pom.xml in spec directory

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -71,6 +71,7 @@
                 </execution>
             </executions>
             <configuration>
+                <sourceDirectory>src/main/asciidoc</sourceDirectory>
                 <sourceDocumentName>jakarta_nosql_spec.adoc</sourceDocumentName>
                 <sourceHighlighter>coderay</sourceHighlighter>
                 <embedAssets>true</embedAssets>


### PR DESCRIPTION
This PR adds an explicit <sourceDirectory> tag that points to src/main/asciidoc.
