### PR TITLE
Remove redundant text and add the correct contributors URL in :author…

### DIFF
--- a/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
+++ b/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
@@ -9,7 +9,7 @@
 :doctype: book
 :license: Apache License v2.0
 :source-highlighter: coderay
-:authors: Contributors to Jakarta NoSQL Specification (https://github.com/jakartaee/data/graphs/contributors)
+:authors: https://github.com/eclipse-ee4j/nosql/graphs/contributors
 :email: nosql-dev@eclipse.org
 ifdef::backend-pdf[]
 :pagenums:


### PR DESCRIPTION
…: attribute of jakarta_nosql_spec.adoc file

I inadvertently added the contributors link to Jakarta Data and realized that there was redundant text. This PR cleans this up.
