### PR TITLE
Update license headers in documentation

### DIFF
--- a/spec/src/main/asciidoc/chapters/communication/communication.adoc
+++ b/spec/src/main/asciidoc/chapters/communication/communication.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/communication/communication_query.adoc
+++ b/spec/src/main/asciidoc/chapters/communication/communication_query.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Otavio Santana, Leonardo de Moura Rocha Lima and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/introduction/goals.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/goals.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 
 === Jakarta NoSQL Project Team
 
-This specification is being developed as part of Jakarta NoSQL Web project under the
+This specification is being developed as part of Jakarta NoSQL project under the
 Jakarta EE Specification Process. It is the result of the collaborative work
 of the project committers and various contributors.
 

--- a/spec/src/main/asciidoc/chapters/license/license-alv2.asciidoc
+++ b/spec/src/main/asciidoc/chapters/license/license-alv2.asciidoc
@@ -1,9 +1,16 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
 // http://www.eclipse.org/legal/epl-2.0.
-
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 [subs="normal"]
 ....

--- a/spec/src/main/asciidoc/chapters/mapping/annotations.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/annotations.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Otavio Santana, Leonardo de Moura Rocha Lima and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/bean_validation.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/bean_validation.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Otavio Santana, Leonardo de Moura Rocha Lima and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/mapping.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/mapping.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/mapping_query.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/mapping_query.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/pagination.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/pagination.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/repository.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/repository.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/template_column.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_column.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/template_document.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_document.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/template_graph.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_graph.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/mapping/template_key_value.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_key_value.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/references/references.adoc
+++ b/spec/src/main/asciidoc/chapters/references/references.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Otavio Santana and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/chapters/types/types.adoc
+++ b/spec/src/main/asciidoc/chapters/types/types.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Otavio Santana, Roan Brasil Monteiro and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
+++ b/spec/src/main/asciidoc/jakarta_nosql_spec.adoc
@@ -1,9 +1,16 @@
-// Copyright (c) 2019-2020 Otavio Santana, Roan Brasil Monteiro and others
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
 // http://www.eclipse.org/legal/epl-2.0.
 //
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 = Jakarta NoSQL
 :authors: Contributors to Jakarta NoSQL Specification (https://github.com/eclipse-ee4j/nosql/graphs/contributors)


### PR DESCRIPTION
The license headers have been updated to reflect the copyright to the contributors to the Eclipse Foundation.  The source code will be next.
