### PR TITLE
Update license headers in source code in tck folder

### DIFF
--- a/tck/communication-tck/communication-tck-column/pom.xml
+++ b/tck/communication-tck/communication-tck-column/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnConditionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnDeleteQueryTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnDeleteQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnEntityTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnEntityTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnParamsTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnParamsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnQueryParserTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnQueryParserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnQueryTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnsTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/ColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/DeleteQueryBuilderTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/DeleteQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/DeleteQueryFluentBuilderTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/DeleteQueryFluentBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/SelectQueryBuilderTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/SelectQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/SelectQueryFluentBuilderTest.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/jakarta/nosql/communication/column/SelectQueryFluentBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-column/src/main/java/module-info.java
+++ b/tck/communication-tck/communication-tck-column/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/pom.xml
+++ b/tck/communication-tck/communication-tck-core/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ParamValueTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ParamValueTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SettingsBuilderTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SettingsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SettingsTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SettingsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SortTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/SortTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ValueReaderDecoratorTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ValueReaderDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ValueTest.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/jakarta/nosql/communication/tck/ValueTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-core/src/main/java/module-info.java
+++ b/tck/communication-tck/communication-tck-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/pom.xml
+++ b/tck/communication-tck/communication-tck-document/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DeleteQueryBuilderTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DeleteQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DeleteQueryFluentBuilderTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DeleteQueryFluentBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentConditionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentDeleteQueryTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentDeleteQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentEntityTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentEntityTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentParamsTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentParamsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentQueryParserTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentQueryParserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentQueryTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentsTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/DocumentsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/SelectQueryBuilderTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/SelectQueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/SelectQueryFluentBuilderTest.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/jakarta/nosql/communication/tck/document/SelectQueryFluentBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-document/src/main/java/module-info.java
+++ b/tck/communication-tck/communication-tck-document/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-key-value/pom.xml
+++ b/tck/communication-tck/communication-tck-key-value/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-key-value/src/main/java/jakarta/nosql/communication/tck/keyvalue/KeyValueEntityTest.java
+++ b/tck/communication-tck/communication-tck-key-value/src/main/java/jakarta/nosql/communication/tck/keyvalue/KeyValueEntityTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-key-value/src/main/java/jakarta/nosql/communication/tck/keyvalue/KeyValueQueryParserTest.java
+++ b/tck/communication-tck/communication-tck-key-value/src/main/java/jakarta/nosql/communication/tck/keyvalue/KeyValueQueryParserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/communication-tck-key-value/src/main/java/module-info.java
+++ b/tck/communication-tck/communication-tck-key-value/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/communication-tck/pom.xml
+++ b/tck/communication-tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/pom.xml
+++ b/tck/driver-tck/driver-tck-column/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnArgument.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnArgument.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnArgumentProvider.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnArgumentProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnConfigurationTest.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnDriverException.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnDriverException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnFamilyManagerSupplier.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnFamilyManagerSupplier.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnFamilyManagerTest.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnFamilyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnSource.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/jakarta/nosql/tck/communication/driver/column/ColumnSource.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-column/src/main/java/module-info.java
+++ b/tck/driver-tck/driver-tck-column/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/pom.xml
+++ b/tck/driver-tck/driver-tck-document/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentArgument.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentArgument.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentArgumentProvider.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentArgumentProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentCollectionManagerSupplier.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentCollectionManagerSupplier.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentCollectionManagerTest.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentCollectionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentConfigurationTest.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentDriverException.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentDriverException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentSource.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/jakarta/nosql/tck/communication/driver/document/DocumentSource.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-document/src/main/java/module-info.java
+++ b/tck/driver-tck/driver-tck-document/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/pom.xml
+++ b/tck/driver-tck/driver-tck-key-value/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/BucketManagerSupplier.java
+++ b/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/BucketManagerSupplier.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/BucketManagerTest.java
+++ b/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/BucketManagerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/KeyValueConfigurationTest.java
+++ b/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/KeyValueConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/User.java
+++ b/tck/driver-tck/driver-tck-key-value/src/main/java/jakarta/nosql/tck/communication/driver/keyvalue/User.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/driver-tck-key-value/src/main/java/module-info.java
+++ b/tck/driver-tck/driver-tck-key-value/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Otavio Santana and others
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/driver-tck/pom.xml
+++ b/tck/driver-tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at

--- a/tck/mapping-tck/mapping-tck-column/pom.xml
+++ b/tck/mapping-tck/mapping-tck-column/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterConstructorTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterInheritanceTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnEntityConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnMapperDeleteBuilderTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnMapperDeleteBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnMapperSelectBuilderTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnMapperSelectBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnQueryMapperBuilderTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnQueryMapperBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnQueryPaginationTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnQueryPaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryPaginationTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryPaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositorySortTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositorySortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnTemplateProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/jakarta/nosql/tck/mapping/column/ColumnTemplateProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-column/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-column/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-core/pom.xml
+++ b/tck/mapping-tck/mapping-tck-core/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-core/src/main/java/jakarta/nosql/tck/mapping/PaginationTest.java
+++ b/tck/mapping-tck/mapping-tck-core/src/main/java/jakarta/nosql/tck/mapping/PaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-core/src/main/java/jakarta/nosql/tck/mapping/SortsTest.java
+++ b/tck/mapping-tck/mapping-tck-core/src/main/java/jakarta/nosql/tck/mapping/SortsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-core/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/pom.xml
+++ b/tck/mapping-tck/mapping-tck-document/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterConstructorTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterInheritanceTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentEntityConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentMapperDeleteBuilderTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentMapperDeleteBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentMapperSelectBuilderTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentMapperSelectBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentQueryMapperTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentQueryMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryPaginationTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryPaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositorySortTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositorySortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentTemplateProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/jakarta/nosql/tck/mapping/document/DocumentTemplateProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-document/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-document/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/pom.xml
+++ b/tck/mapping-tck/mapping-tck-entities/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Actor.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ActorBuilder.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ActorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Address.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Animal.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/AppointmentBook.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/AppointmentBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Book.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/BookRepository.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/BookRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Car.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Car.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Contact.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Contact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ContactType.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ContactType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Director.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Director.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Download.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Download.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/IgnoreRepository.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/IgnoreRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Job.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Machine.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Machine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Money.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/MoneyConverter.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/MoneyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Movie.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/NoConstructorEntity.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/NoConstructorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Person.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonBuilder.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonIgnoreRepository.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonIgnoreRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonRepository.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PersonRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Plate.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Plate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PlateConverter.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/PlateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/User.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/UserRepository.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/UserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Vendor.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Vendor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Worker.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/Worker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/WrongEntity.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/WrongEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ZipCode.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/ZipCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/BookUser.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/BookUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/Computer.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/Computer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/PetOwner.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/constructor/PetOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/EmailNotification.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/EmailNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/LargeProject.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/LargeProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/Notification.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/Notification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/NotificationReader.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/NotificationReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/Project.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/ProjectManager.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/ProjectManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SmallProject.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SmallProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SmsNotification.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SmsNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SocialMediaNotification.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/jakarta/nosql/tck/entities/inheritance/SocialMediaNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-entities/src/main/resources/META-INF/beans.xml
+++ b/tck/mapping-tck/mapping-tck-entities/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/pom.xml
+++ b/tck/mapping-tck/mapping-tck-key-value/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueEntityConverterTest.java
+++ b/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueEntityConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueRepositoryProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueRepositoryProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueRepositoryTest.java
+++ b/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueTemplateProducerTest.java
+++ b/tck/mapping-tck/mapping-tck-key-value/src/main/java/jakarta/nosql/tck/mapping/keyvalue/KeyValueTemplateProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-key-value/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-key-value/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/pom.xml
+++ b/tck/mapping-tck/mapping-tck-test/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/AnnotationUtils.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/AnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/CDIExtension.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/CDIExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/CDIJUnitExtension.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/CDIJUnitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/ContainerSupplier.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/ContainerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/Preconditions.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/jakarta/nosql/tck/test/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/java/module-info.java
+++ b/tck/mapping-tck/mapping-tck-test/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Otavio Santana and others
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/mapping-tck-test/src/main/resources/META-INF/beans.xml
+++ b/tck/mapping-tck/mapping-tck-test/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/mapping-tck/pom.xml
+++ b/tck/mapping-tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Otavio Santana and others
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License v. 2.0 which is available at
   ~ http://www.eclipse.org/legal/epl-2.0.

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~  Copyright (c) 2020 Otavio Santana and others
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
   ~  This program and the accompanying materials are made available under the
   ~  terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
This PR updates the license headers in the source code located in the tcf folder
