### PR TITLE
Documentation updates

### DIFF
--- a/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
@@ -18,9 +18,14 @@
 
 Jakarta NoSQL is a Java framework that streamlines the integration of Java applications with NoSQL databases.
 
+Jakarta NoSQL defines an API for each NoSQL database type:
 
-Jakarta NoSQL defines an API for each NoSQL database type. However, it uses the same annotations to map Java objects.
-Therefore, with just these annotations that look like JPA, there is support for more than twenty NoSQL databases.
+* Key-Value
+* Column Family
+* Document
+* Graph
+
+However, it uses the same annotations to map Java objects. Therefore, with just these annotations, whose names match those from the Jakarta Persistence specification, there is support for more than twenty NoSQL databases.
 
 [source,java]
 ----
@@ -39,30 +44,30 @@ public class Deity {
 }
 ----
 
-Vendor lock-in is one of the things any Java project needs to consider when choosing NoSQL databases. If there is a need to switch out a database, other considerations include: time spent on the change; the learning curve of a new database API; the code that will be lost; the persistence layer that needs to be replaced, etc. Jakarta NoSQL avoids most of these issues through the APIs of *Communication* and *Mapping* Layers.
+Developers need to consider vendor lock-in when choosing a NoSQL database for their application. For example, if there is a need to switch out a database considerations include: the time spent on the change; the learning curve of a new database API; the code that will be lost; the persistence layer that needs to be replaced, etc. Jakarta NoSQL avoids most of these issues through the *Mapping* API.
 
-Jakarta NoSQL also has template classes that apply the design pattern 'template method’ to databases operations.
-
+Jakarta NoSQL also provides template classes that apply the *Template Method* design pattern to all database operations.
 
 === Beyond Jakarta Persistence (JPA)
 
-The https://jakarta.ee/specifications/persistence/[Jakarta Persistence] specification is a good API for object-relational mapping and has established itself as a Jakarta EE standard. It would be ideal to use the same API for both SQL and NoSQL, but there are behaviors in NoSQL that SQL does not cover, such as time to live and asynchronous operations. Jakarta Persistence was simply not designed to handle those features.
+The https://jakarta.ee/specifications/persistence/[Jakarta Persistence] specification is an excellent API for object-relational mapping and has established itself as a Jakarta EE standard. It would be ideal to use the same API for both SQL and NoSQL, but there are behaviors in NoSQL that SQL does not cover, such as time-to-live and asynchronous operations. Jakarta Persistence was simply not designed to handle those features.
 
 [source,java,subs="quotes"]
 ----
-ColumnTemplate template = // instance;
+ColumnTemplate template = // instance; a template to document NoSQL operations
 Deity diana = Deity.builder()
         .withId("diana")
         .withName("Diana")
         .withPower("hunt")
         .build();
+
 *Duration ttl = Duration.ofSeconds(1);*
 template.insert(diana, *ttl*);
 ----
 
 === A Fluent API
 
-Jakarta NoSQL is a fluent API for Java developers to more easily create queries that either retrieve or delete information in a `Document` database type, for example.
+Jakarta NoSQL is a fluent API for Java developers to more easily create queries that either retrieve or delete information in a `Document` database type. For example:
 
 [source,java]
 ----
@@ -85,18 +90,17 @@ template.delete(Deity.class).where("name")
 
 === Let's Not Reinvent the Wheel: Graph Database Type
 
-The Communication Layer defines three new APIs: Key-Value, Document and Column Family. It does not have new Graph API, because a very good one already exists. Apache TinkerPop is a graph computing framework for both graph databases (OLTP) and graph analytic systems (OLAP). Using Apache TinkerPop as Communication API for Graph databases, the Mapping API has a tight integration with it.
+The Communication layer defines three new APIs for NoSQL database types: Key-Value, Column Family and Document. It does not provide the new Graph API because a very good one already exists. https://tinkerpop.apache.org/[Apache TinkerPop] is a graph computing framework for both graph databases (OLTP) and graph analytic systems (OLAP). Using Apache TinkerPop as the Communication API for Graph databases, the Mapping API has a tight integration with it.
 
 === Particular Behavior Matters in NoSQL Databases
 
-Particular behavior matters. Even within the same type, each NoSQL database has a unique feature that may be a considerable factor when choosing one database over another. This ‘’feature’’ might make it easier to develop, make it more scaleable or consistent from a configuration standpoint, have the desired consistency level or search engine, etc. Some examples include: Cassandra and its Cassandra Query Language and consistency level; OrientDB with live queries; ArangoDB and its Arango Query Language; Couchbase with N1QL; etc. Each NoSQL database has a specific behavior and this behavior matters, so Jakarta NoSQL was designed to be extensible enough to capture these substantially different feature elements.
-
+Even within the same type, each NoSQL database has a unique feature that may be a considerable factor when choosing one database over another. This "feature" might make it easier to develop, make it more scaleable or consistent from a configuration standpoint, have the desired consistency level or search engine, etc. Some examples include: Cassandra and its Cassandra Query Language and consistency level; OrientDB with live queries; ArangoDB and its Arango Query Language; Couchbase with N1QL; etc. Each NoSQL database has a specific behavior and this behavior matters, so Jakarta NoSQL was designed to be extensible enough to capture these substantially different feature elements.
 
 === Key Features
 
-* Simple APIs supporting all well-known NoSQL storage types - Column Family, Key-Value Pair, Graph and Document databases.
+* Simple APIs that support all well-known NoSQL storage types: Key-Value, Column Family, Document and Graph databases
 * Use of Convention Over Configuration
 * Easy-to-implement API Specification and Technology Compatibility Kit (TCK) for NoSQL Vendors
-* The APIs focus is on simplicity and ease of use. Developers should only have to know a minimal set of artifacts to work with Jakarta NoSQL. The API is built on Java 8 features like Lambdas and Streams, and therefore fits perfectly with the functional features of Java 8+.
+* The APIs focus is on simplicity and ease-of-use. Developers should only have to know a minimal set of artifacts to work with Jakarta NoSQL. The API is built on Java 8 features like Lambdas and Streams, and therefore fits perfectly with the functional features of Java 8+.
 
 include::project_team.adoc[]

--- a/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
@@ -20,28 +20,34 @@ of the project committers and various contributors.
 
 ==== Project Lead
 
-* Otavio Santana
+* https://projects.eclipse.org/content/otavio-santana-project-lead-jakarta-nosql[Otavio Santana]
+
+==== Contributors
+
+* https://projects.eclipse.org/user/8408[Ivar Grimstad]
+* https://projects.eclipse.org/user/8180[Kevin Sutter]
+* https://projects.eclipse.org/user/10810[Scott Stark]
 
 ==== Committers
 
-* Andres Galante
-* Fred Rowe
-* Gaurav Gupta
-* Ivan Junckes Filho
-* Jesse Gallagher
-* Nathan Rauh
-* Otavio Santana
-* Werner Keil
-* Michael Redlich
+* https://projects.eclipse.org/content/andres-galante-committer-jakarta-nosql[Andres Galante]
+* https://projects.eclipse.org/content/fred-rowe-committer-jakarta-nosql[Fred Rowe]
+* https://projects.eclipse.org/content/gaurav-gupta-committer-jakarta-nosql[Gaurav Gupta]
+* https://projects.eclipse.org/content/ivan-junckes-filho-committer-jakarta-nosql[Ivan Junckes Filho]
+* https://projects.eclipse.org/content/jesse-gallagher-committer-jakarta-nosql[Jesse Gallagher]
+* https://projects.eclipse.org/content/michael-redlich-committer-jakarta-nosql[Michael Redlich]
+* https://projects.eclipse.org/content/nathan-rauh-committer-jakarta-nosql[Nathan Rauh]
+* https://projects.eclipse.org/content/otavio-santana-committer-jakarta-nosql[Otavio Santana]
+* https://projects.eclipse.org/content/werner-keil-committer-jakarta-nosql[Werner Keil]
 
 ==== Historical Committer
 
-* Leonardo Lima
+* https://projects.eclipse.org/content/leonardo-lima-committer-jakarta-nosql[Leonardo Lima]
 
 ==== Mentor
 
-* Wayne Beaton
+* https://projects.eclipse.org/content/wayne-beaton-mentor-jakarta-nosql[Wayne Beaton]
 
-==== Contributors
+==== Full List of Contributors
 
 The complete list of Jakarta NoSQL contributors may be found https://github.com/eclipse-ee4j/nosql/graphs/contributors[here].

--- a/spec/src/main/asciidoc/chapters/mapping/annotations.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/annotations.adoc
@@ -23,15 +23,15 @@ As previously mentioned, the Mapping API provides annotations that make the Java
 
 The annotation model converts the entity model into the entity on communication, the communication entity:
 
-* Entity
-* Column
-* Id
+* @Entity
+* @Column
+* @Id
 
-Jakarta NoSQL Mapping does not require getter and setter methods to fields. However, the Entity class must have a non-private constructor with no parameters.
+The Jakarta NoSQL Mapping API does not require getter and setter methods to fields. However, the Entity class must have a non-private constructor with no parameters.
 
 ===== @Entity
 
-This annotation maps the class to Jakarta NoSQL. There is a single value attribute. This attribute specifies the column family name, or the document collection name, etc. The default value is the simple name of the class. For example, given the `org.jakarta.nosql.demo.Person` class, the default name will be `Person`.
+This annotation maps the class to Jakarta NoSQL. There is a single value attribute that specifies the column family name, the document collection name, etc. The default value is the simple name of the class. For example, given the `org.jakarta.nosql.demo.Person` class, the default name will be `Person`.
 
 [source,java]
 ----
@@ -86,9 +86,10 @@ public class Address {
    }
 }
 ----
+
 ===== @Column
 
-This annotation defines which fields that belong to an Entity will be persisted. There is a single attribute that specifies that name in Database. It is default value that is the field name as declared in the class. This annotation is mandatory for non-Key-Value database types. In Key-Value types, only the Key needs to be identified with `@Key` - all other fields are stored as a single blob.
+This annotation defines which fields that belong to an Entity will be persisted. There is a single attribute that specifies that name in Database with a default value that is the field name as declared in the class. This annotation is mandatory for non-Key-Value database types. In Key-Value types, only the Key needs to be identified with the `@Key` annotation. All other fields are stored as a single BLOB.
 
 [source,java]
 ----

--- a/spec/src/main/asciidoc/chapters/mapping/mapping.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/mapping.adoc
@@ -16,40 +16,53 @@
 
 The mapping level, to put it differently, has the same goals as either the JPA or ORM. In the NoSQL world, the *OxM* then converts the entity object to a communication model.
 
-This level is in charge to perform integration among technologies such as Bean Validation. The Mapping API has annotations that make the Java developer’s life easier. As a communication project, it must be extensible and configurable to keep the diversity of NoSQL database.
-
-IMPORTANT: The package name might change on the Jakarta EE process.
+This level is responsible to perform integration among technologies such as https://jakarta.ee/specifications/bean-validation/[Bean Validation]. The Mapping API provides annotations that make the Java developer's life easier. As a communication project, it must be extensible and configurable to keep the diversity of NoSQL databases.
 
 include::annotations.adoc[]
 
-=== Template classes
+=== Template Classes
 
-The Template offers convenient creation, update, delete, and query operations for databases. The `Template` instance is the root implementation for all types. So, each database type will support this instance.
+The Template classes offer convenient creation, update, delete, and query operations for databases. The `Template` instance is the root implementation for all types. So, each database type will support this instance.
 
 [source,java]
 ----
 @Inject
 Template template;
 
+Book book = Book.builder()
+        .id(id)
+        .title("Java Concurrency in Practice")
+        .author("Brian Goetz")
+        .year(Year.of(2006))
+        .edition(1)
+        .build();
 
-Book book = Book.builder().id(id).title("Java Concurrency in Practice")
-.author("Brian Goetz").year(Year.of(2006)).edition(1).build();
 template.insert(book);
 Optional<Book> optional = template.find(Book.class, id);
 System.out.println("The result " + optional);
 template.delete(Book.class, id);
 ----
 
-Furthermore, in the CRUD operation, Template has two queries, fluent-API for either select or delete entities; thus, Template offers the capability for search and remove beyond the ID attribute.
+Furthermore, in CRUD operations, Template provides two queries, a fluent-API for either select or delete entities. Thus, Template offers the capability for search and remove beyond the ID attribute.
 
 [source,java]
 ----
 @Inject
 Template template;
 
-List<Book> books = template.select(Book.class).where("author").eq("Joshua Bloch").and("edition").gt(3).result();
+List<Book> books = template.select(Book.class)
+        .where("author")
+        .eq("Joshua Bloch")
+        .and("edition")
+        .gt(3)
+        .result();
 
-template.select(Book.class).where("author").eq("Joshua Bloch").and("edition").gt(3).execute();
+template.select(Book.class)
+        .where("author")
+        .eq("Joshua Bloch")
+        .and("edition")
+        .gt(3)
+        .execute();
 ----
 
 include::template_key_value.adoc[]

--- a/spec/src/main/asciidoc/chapters/mapping/mapping_query.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/mapping_query.adoc
@@ -14,7 +14,7 @@
 
 ====  Querying by Text with the Mapping API
 
-Jakarta NoSQL has query by text where you can execute it; furthermore, there is the option to explore prepare statement query. Jakarta NoSQL does not provide any query support; thus, any vendor might have diverse queries.
+Jakarta NoSQL provides query by text that you can execute. Furthermore, there is the option to explore a prepared statement query. Jakarta NoSQL does not provide any query support. Thus, any vendor might have diverse queries.
 
 ===== Key-Value Database Types
 
@@ -25,17 +25,13 @@ Stream<User> users = template.query("get \"Diana\"");
 template.query("remove \"Diana\"");
 ----
 
-
 ===== Column-Family Database Types
-
-
 
 [source,java]
 ----
 ColumnTemplate template = // instance;
 Stream<Person> result = template.query("select * from Person where id = 1");
 ----
-
 
 ===== Document Database Types
 

--- a/spec/src/main/asciidoc/chapters/mapping/template_column.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_column.adoc
@@ -62,9 +62,18 @@ public class Person {
 @Inject
 ColumnTemplate template;
 ...
-List<Person> people = template.select(Person.class).where("id").gte(10).result();
+List<Person> people = template.select(Person.class)
+        .where("id")
+        .gte(10)
+        .result();
+
 // translating: select().from("Person").where("native_id").gte(10L).build();
-template.delete(Person.class).where("id").eq("20").execute();
+
+template.delete(Person.class)
+        .where("id")
+        .eq("20")
+        .execute();
+
 // translating: delete().from("Person").where("native_id").gte(10L).build();
 
 ----

--- a/spec/src/main/asciidoc/chapters/mapping/template_document.adoc
+++ b/spec/src/main/asciidoc/chapters/mapping/template_document.adoc
@@ -43,7 +43,6 @@ template.update(people);
 
 To remove and retrieve information from document collection, there are `select` and `delete` methods.
 
-
 [source,java]
 ----
 @Entity
@@ -66,14 +65,21 @@ public class Person {
 private DocumentTemplate template;
 
 public void mapper() {
-List<Person> people = template.select(Person.class).where("id")
-                                     .gte(10).result();
-  // translating: select().from("Person").where("native_id").gte(10L).build();
-template.delete(Person.class).where("id").eq("20").execute();
+List<Person> people = template.select(Person.class)
+        .where("id")
+        .gte(10)
+        .result();
+
+// translating: select().from("Person").where("native_id").gte(10L).build();
+
+template.delete(Person.class)
+        .where("id")
+        .eq("20")
+        .execute();
+
 // translating: delete().from("Person").where("native_id").gte(10L).build();
 }
 ----
-
 
 To use a document template, just follow the CDI style and place an `@Inject` annotation on the field.
 

--- a/spec/src/main/asciidoc/chapters/references/references.adoc
+++ b/spec/src/main/asciidoc/chapters/references/references.adoc
@@ -51,10 +51,7 @@ Stardog:: https://www.stardog.com/
 TitanDB:: http://titan.thinkaurelius.com/
 Memcached:: https://memcached.org/
 
-
-
 === Articles
-
 
 Graph Databases for Beginners: ACID vs. BASE Explained:: https://neo4j.com/blog/acid-vs-base-consistency-models-explained/
 Base: An Acid Alternative:: https://queue.acm.org/detail.cfm?id=1394128
@@ -64,4 +61,3 @@ List of NoSQL databases:: http://nosql-database.org/
 Data access object Wiki:: https://en.wikipedia.org/wiki/Data_access_object
 CAP Theorem and Distributed Database Management Systems:: https://towardsdatascience.com/cap-theorem-and-distributed-database-management-systems-5c2be977950e
 Oracle Java EE 9 NoSQL view:: https://javaee.github.io/javaee-spec/download/JavaEE9.pdf
-


### PR DESCRIPTION
These are the updates to the documentation as requested.  Please note that there is still a reference to the Communication API when discussing the use of Apache TinkerPop for the Graph NoSQL database type.
