### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/api/nosql-core/src/main/java/jakarta/nosql/package-info.java
+++ b/api/nosql-core/src/main/java/jakarta/nosql/package-info.java
@@ -16,8 +16,7 @@
 
 /**
  * Defines the core API in mapping level.
- * It brings an easy interface to support key-value, column family, document oriented and graph
- * databases using as base Jakarta NoSQL in CDI based.
+ * It brings an easy interface to support NoSQL databases using as base Jakarta NoSQL.
  * The API's focus is on simplicity and ease of use.
  * <ul>
  * <li>CDI Based</li>

--- a/api/nosql-core/src/main/java/module-info.java
+++ b/api/nosql-core/src/main/java/module-info.java
@@ -14,6 +14,5 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 module jakarta.nosql.core {
-    requires jakarta.data.api;
     exports jakarta.nosql;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>jakarta.data</groupId>
-            <artifactId>jakarta-data-api</artifactId>
-            <version>${jakarta.data.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <apache.rat.version>0.12</apache.rat.version>
         <checkstyle.excludes></checkstyle.excludes>
         <jacoco.maven.version>0.8.7</jacoco.maven.version>
-        <jakarta.data.version>1.0.0-b1</jakarta.data.version>
         <maven-javadoc-plugin.vesion>3.3.2</maven-javadoc-plugin.vesion>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>

--- a/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/introduction.adoc
@@ -23,7 +23,6 @@ Jakarta NoSQL defines an API for each NoSQL database type:
 * Key-Value
 * Column Family
 * Document
-* Graph
 
 However, it uses the same annotations to map Java objects. Therefore, with just these annotations, whose names match those from the Jakarta Persistence specification, there is support for more than twenty NoSQL databases.
 
@@ -88,9 +87,6 @@ template.delete(Deity.class).where("name")
         .eq("Diana").execute();
 ----
 
-=== Let's Not Reinvent the Wheel: Graph Database Type
-
-The Communication layer defines three new APIs for NoSQL database types: Key-Value, Column Family and Document. It does not provide the new Graph API because a very good one already exists. https://tinkerpop.apache.org/[Apache TinkerPop] is a graph computing framework for both graph databases (OLTP) and graph analytic systems (OLAP). Using Apache TinkerPop as the Communication API for Graph databases, the Mapping API has a tight integration with it.
 
 === Particular Behavior Matters in NoSQL Databases
 
@@ -98,7 +94,7 @@ Even within the same type, each NoSQL database has a unique feature that may be 
 
 === Key Features
 
-* Simple APIs that support all well-known NoSQL storage types: Key-Value, Column Family, Document and Graph databases
+* Simple APIs that support all well-known NoSQL storage types: Key-Value, Column Family, Document databases
 * Use of Convention Over Configuration
 * Easy-to-implement API Specification and Technology Compatibility Kit (TCK) for NoSQL Vendors
 * The APIs focus is on simplicity and ease-of-use. Developers should only have to know a minimal set of artifacts to work with Jakarta NoSQL. The API is built on Java 8 features like Lambdas and Streams, and therefore fits perfectly with the functional features of Java 8+.


### PR DESCRIPTION

This PR removes the Graph reference, once we're not supporting yet and Jakarta Data as a direct dependency once it does not neet it.