### PR TITLE
Fix links in POM

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,6 +24,8 @@
     <dependencies>
     </dependencies>
 
+    <url>https://projects.eclipse.org/projects/ee4j.nosql</url>
+
     <scm>
         <connection>scm:git:git://github.com/jakartaee/nosql.git</connection>
         <developerConnection>scm:git:ssh://github.com:jakartaee/nosql.git</developerConnection>


### PR DESCRIPTION
As in maven project child's `<url>` and `<scm>*` are _inherited and enhanced_ if not set explicitly - I propose to explicitly set them in pom to avoid invalid values.

Currently - https://central.sonatype.com/artifact/jakarta.nosql/jakarta.nosql-api/1.0.1

- "Project URL" leads to http://www.eclipse.org/ee4j/nosql/jakarta.nosql-api which is 404.
I propose to link to page that _Eclipse project finder_ does.
- "Source Control" leads to https://github.com/jakartaee/nosql/jakarta.nosql-api, which is 404.
I propose to link to top-level repository, as seen in parent.