### PR TITLE
API improvements to update query fluency and Documentation and example enhancements

### DIFF
--- a/api/src/main/java/jakarta/nosql/QueryMapper.java
+++ b/api/src/main/java/jakarta/nosql/QueryMapper.java
@@ -30,18 +30,31 @@ import java.util.stream.Stream;
  *
  * @see jakarta.nosql.Template#select(Class)
  * @see jakarta.nosql.Template#delete(Class)
+ * @see jakarta.nosql.Template#update(Class)
  * @since 1.0.0
  */
 public interface QueryMapper {
 
-
     /**
      * Represents the first step in the delete query fluent API.
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").eq("Ada")
+     *     .execute();
+     * }</pre>
      */
     interface MapperDeleteFrom extends MapperDeleteQueryBuild {
 
         /**
          * Starts a new delete condition by specifying a column name.
+         * <pre>{@code
+         * template.delete(Book.class)
+         *     .where("author").eq("Ada")
+         *     .execute();
+         * }</pre>
          *
          * @param name the column name
          * @return a new {@link MapperDeleteNameCondition}
@@ -51,7 +64,26 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents a delete condition based on a column name.
+     * Represents a delete condition based on a column name in the fluent delete API.
+     * <p>
+     * This interface defines the available comparison operations that can be applied
+     * to a column when building a delete query. It is reached after specifying a
+     * column name using {@code where(String)} and allows defining predicates such as
+     * equality, pattern matching, range comparisons, and negation.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").eq("Ada")
+     *     .execute();
+     * }</pre>
+     *
+     * The returned instances are mutable and not thread-safe.
+     * Support for specific comparison operations depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperDeleteNameCondition {
 
@@ -224,19 +256,52 @@ public interface QueryMapper {
 
     /**
      * Represents a NOT delete condition in the delete query fluent API.
+     * <p>
+     * This interface is used to negate the next delete condition applied to a
+     * column. It is typically reached by invoking {@code not()} after specifying
+     * a column name and allows composing negated predicates.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").not().eq("Ada")
+     *     .execute();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for negated conditions depends on the capabilities of the underlying
+     * NoSQL database.
      */
     interface MapperDeleteNotCondition extends MapperDeleteNameCondition {
     }
 
     /**
-     * Represents the last step of the delete query fluent API execution.
+     * Represents the final execution step of the delete query fluent API.
+     * <p>
+     * This interface defines the terminal operation used to execute a delete
+     * query after all conditions have been specified.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").eq("Ada")
+     *     .and("publishedYear").gte(2020)
+     *     .execute();
+     * }</pre>
      */
     interface MapperDeleteQueryBuild {
 
-
         /**
-         *  Executes the delete query based on the specified conditions.
-         *  Use this method to remove entities from the database that match the defined criteria.
+         * Executes the delete query based on the specified conditions.
+         * Use this method to remove entities from the database that match the
+         * defined criteria.
+         *
          * <pre>{@code
          * template.delete(Book.class)
          *         .where("author").eq("Ada")
@@ -244,35 +309,71 @@ public interface QueryMapper {
          *         .execute();
          * }</pre>
          *
-         * @throws UnsupportedOperationException If a NoSQL database does not support a specific operation or if the
-         *                                       database does not support certain query conditions, an exception will be raised. For example, a wide-column
-         *                                       may not support the OR operator, or a document database may not support the BETWEEN operator.
-         *                                       The level of NoSQL database support for various conditions may vary depending on the database provider.
+         * @throws UnsupportedOperationException if the underlying NoSQL database
+         *         does not support a specific delete operation or query condition.
+         *         For example, a wide-column database may not support the OR
+         *         operator, or a document database may not support the BETWEEN
+         *         operator. Support for delete operations and conditions varies
+         *         depending on the database provider.
          */
         void execute();
-
     }
 
     /**
-     * Represents a step where it's possible to perform a logical conjunction or disjunction,
-     * add one more delete condition, or end up performing the built query.
+     * Represents a step where it is possible to compose delete conditions using
+     * logical conjunctions or disjunctions, or execute the built delete query.
+     * <p>
+     * This step is reached after a delete condition has been defined and allows
+     * combining additional conditions using {@code and(...)} or {@code or(...)},
+     * or finalizing the operation by executing the query.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").eq("Ada")
+     *     .and("publishedYear").gte(2020)
+     *     .execute();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for logical operators depends on the capabilities of the underlying
+     * NoSQL database.
      */
     interface MapperDeleteWhere extends MapperDeleteQueryBuild {
 
         /**
-         * Create a new delete condition performing logical conjunction (AND) by specifying a column name.
+         * Creates a new delete condition using logical conjunction (AND) by
+         * specifying a column name.
+         *
+         * <pre>{@code
+         * template.delete(Book.class)
+         *     .where("author").eq("Ada")
+         *     .and("publishedYear").gte(2020)
+         *     .execute();
+         * }</pre>
          *
          * @param name the column name
-         * @return the same {@link MapperDeleteNameCondition} with the delete condition appended
+         * @return the {@link MapperDeleteNameCondition} with the delete condition appended
          * @throws NullPointerException when name is null
          */
         MapperDeleteNameCondition and(String name);
 
         /**
-         * Create a new delete condition performing logical disjunction (OR) by specifying a column name.
+         * Creates a new delete condition using logical disjunction (OR) by
+         * specifying a column name.
+         *
+         * <pre>{@code
+         * template.delete(Book.class)
+         *     .where("author").eq("Ada")
+         *     .or("author").eq("Hermann")
+         *     .execute();
+         * }</pre>
          *
          * @param name the column name
-         * @return the same {@link MapperDeleteNameCondition} with the delete condition appended
+         * @return the {@link MapperDeleteNameCondition} with the delete condition appended
          * @throws NullPointerException when name is null
          */
         MapperDeleteNameCondition or(String name);
@@ -348,9 +449,17 @@ public interface QueryMapper {
         /**
          * Assigns the given value to the previously defined field.
          *
+         * <pre>{@code
+         * template.update(Book.class)
+         *     .set("publishedYear").to(2025)
+         *     .where("author").eq("Ada")
+         *     .execute();
+         * }</pre>
+         *
          * @param value the value to assign
          * @param <T>   the value type
          * @return the next step of the update fluent API
+         * @throws NullPointerException when value is null
          */
         <T> MapperUpdateSetStep to(T value);
     }
@@ -382,6 +491,12 @@ public interface QueryMapper {
         /**
          * Starts a new field assignment for the update operation.
          *
+         * <pre>{@code
+         * template.update(Book.class)
+         *     .set("title").to("Domain-Driven Design with Java")
+         *     .execute();
+         * }</pre>
+         *
          * @param name the field name to be updated
          * @return a step that allows assigning a value to the field
          * @throws NullPointerException when the field name is {@code null}
@@ -390,6 +505,13 @@ public interface QueryMapper {
 
         /**
          * Defines a condition to restrict which entities will be updated.
+         *
+         * <pre>{@code
+         * template.update(Book.class)
+         *     .set("available").to(false)
+         *     .where("category").eq("CLASSIC")
+         *     .execute();
+         * }</pre>
          *
          * @param name the field name used in the condition
          * @return the conditional step of the update fluent API
@@ -402,8 +524,8 @@ public interface QueryMapper {
      * Represents the predicate definition step of the fluent update API.
      * <p>
      * This step defines conditional expressions used to restrict which entities
-     * will be affected by an update operation. Each method adds a comparison
-     * predicate for the previously defined field.
+     * will be affected by an update operation. Each predicate applies to the
+     * previously specified field.
      * </p>
      *
      * <p>
@@ -415,6 +537,16 @@ public interface QueryMapper {
      * <p>
      * This step is mutable and not thread-safe.
      * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.update(Book.class)
+     *     .set("published").to(true)
+     *     .where("author").eq("Ada")
+     *     .execute();
+     * }</pre>
      */
     interface MapperUpdateNameCondition {
 
@@ -422,7 +554,7 @@ public interface QueryMapper {
          * Creates an update condition where the specified column name equals the provided value.
          * <pre>{@code
          * template.update(Book.class)
-         *         .set("publishMapperUpdateSetSteped").to(true)
+         *         .set("published").to(true)
          *         .where("author").eq("Ada")
          *         .execute();
          * }</pre>
@@ -617,6 +749,21 @@ public interface QueryMapper {
      * This step allows combining multiple update conditions using logical
      * operators before executing the update operation.
      * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.update(Book.class)
+     *     .set("published").to(true)
+     *     .where("author").eq("Ada")
+     *     .and("publishedYear").gte(2020)
+     *     .execute();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for logical operators depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperUpdateWhere extends MapperUpdateQueryBuild {
 
@@ -656,6 +803,24 @@ public interface QueryMapper {
 
     /**
      * Represents the final execution step of the update query fluent API.
+     * <p>
+     * This interface defines the terminal operation used to execute an update
+     * query after all assignments and conditions have been specified.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.update(Book.class)
+     *     .set("title").to("Domain-Driven Design with Java")
+     *     .set("publishedYear").to(2025)
+     *     .where("author").eq("Ada")
+     *     .execute();
+     * }</pre>
+     *
+     * Support for update operations and conditional execution depends on the
+     * capabilities of the underlying NoSQL database.
      */
     interface MapperUpdateQueryBuild {
 
@@ -680,7 +845,27 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents the first step in the query fluent API.
+     * Represents the initial step of the fluent query API.
+     * <p>
+     * This interface is the entry point for building selection queries and
+     * provides operations to define filtering conditions, pagination, and
+     * result ordering before executing the query.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .orderBy("title").asc()
+     *     .limit(10)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instances are mutable and not thread-safe.
+     * Support for query features depends on the capabilities of the underlying
+     * NoSQL database.
      */
     interface MapperFrom extends MapperQueryBuild {
 
@@ -742,7 +927,29 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents the step in the query fluent API where it's possible to define the maximum number of results to retrieve or to perform the query execution.
+     * Represents the step in the fluent query API where the maximum number of
+     * results has been defined and it is still possible to further refine
+     * pagination or execute the query.
+     * <p>
+     * This step is typically reached after invoking {@code limit(long)} and
+     * allows specifying an optional offset or proceeding directly to query
+     * execution.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .limit(10)
+     *     .skip(5)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for pagination features depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperLimit extends MapperQueryBuild {
 
@@ -761,7 +968,35 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents a condition based on a column name.
+     * Represents a predicate definition step based on a column name in the fluent query API.
+     * <p>
+     * This interface is reached after specifying a column name using {@code where(String)}
+     * and defines the set of comparison and matching operations that can be applied
+     * to that column to filter query results.
+     * </p>
+     *
+     * <p>
+     * Each predicate method produces a conditional expression and returns a
+     * {@link MapperWhere} instance, allowing further condition composition,
+     * ordering, pagination, or query execution.
+     * </p>
+     *
+     * <p>
+     * Support for specific predicate operations depends on the capabilities of
+     * the underlying NoSQL database. Unsupported predicates may result in an
+     * {@link UnsupportedOperationException}.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .result();
+     * }</pre>
+     *
+     * This step is mutable and not thread-safe.
      */
     interface MapperNameCondition {
 
@@ -953,7 +1188,28 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents the step in the query fluent API where it's possible to define the order of the results or to perform the query execution.
+     * Represents the step in the fluent query API where result ordering, pagination,
+     * or query execution can be defined.
+     * <p>
+     * This interface is reached after filtering conditions have been specified and
+     * allows configuring the sort order of results, defining pagination parameters,
+     * or directly executing the query.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .orderBy("title").asc()
+     *     .limit(10)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for ordering and pagination features depends on the capabilities of
+     * the underlying NoSQL database.
      */
     interface MapperNameOrder extends MapperQueryBuild {
 
@@ -1007,12 +1263,49 @@ public interface QueryMapper {
 
     /**
      * Represents a NOT condition in the delete query fluent API.
+     * <p>
+     * This interface is used to negate the next condition applied to a column,
+     * enabling inverse logic when building delete queries.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.delete(Book.class)
+     *     .where("author").not().eq("Ada")
+     *     .execute();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for negated conditions depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperNotCondition extends MapperNameCondition {
     }
 
     /**
-     * Represents the step in the query fluent API where it's possible to define the order of the results or to perform the query execution.
+     * Represents the step in the fluent query API where the sort direction
+     * for a previously specified column is defined.
+     * <p>
+     * This interface is reached after calling {@code orderBy(String)} and
+     * allows selecting the ordering direction (ascending or descending)
+     * before continuing query composition or executing the query.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .orderBy("title").asc()
+     *     .result();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for ordering operations depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperOrder {
 
@@ -1045,7 +1338,28 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents the last step of the query fluent API execution.
+     * Represents the final execution step of the fluent query API.
+     * <p>
+     * This interface defines terminal operations used to execute a query after
+     * all filtering, ordering, and pagination steps have been specified.
+     * It allows retrieving query results in different forms, such as a count,
+     * a list, a stream, or a single optional result.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * List<Book> books = template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .orderBy("title").asc()
+     *     .limit(10)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instances are mutable and not thread-safe.
+     * Support for execution operations depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperQueryBuild {
 
@@ -1124,7 +1438,29 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents the step in the query fluent API where it's possible to define the position of the first result to retrieve or to perform the query execution.
+     * Represents the step in the fluent query API where the position of the first
+     * result to retrieve has been defined and it is still possible to further
+     * refine pagination or execute the query.
+     * <p>
+     * This interface is typically reached after invoking {@code skip(long)} and
+     * allows specifying a maximum number of results or proceeding directly to
+     * query execution.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .skip(10)
+     *     .limit(5)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for pagination features depends on the capabilities of the
+     * underlying NoSQL database.
      */
     interface MapperSkip extends MapperQueryBuild {
 
@@ -1144,15 +1480,29 @@ public interface QueryMapper {
     }
 
     /**
-     * Represents a step where it's possible to:
-     * <ul>
-     *     <li>Create a new condition performing logical conjunction (AND) by specifying a column name</li>
-     *     <li>Create a new condition performing logical disjunction (OR) by specifying a column name</li>
-     *     <li>Define the position of the first result</li>
-     *     <li>Define the maximum number of results to retrieve</li>
-     *     <li>Define the order of the results</li>
-     *     <li>Perform the query execution</li>
-     * </ul>
+     * Represents the step in the fluent query API where conditional composition,
+     * pagination, ordering, or query execution can be defined.
+     * <p>
+     * This interface is reached after an initial predicate has been applied and
+     * allows combining additional conditions using logical operators, configuring
+     * pagination parameters, defining result ordering, or executing the query.
+     * </p>
+     *
+     * <pre>{@code
+     * @Inject
+     * Template template;
+     *
+     * template.select(Book.class)
+     *     .where("author").eq("Ada")
+     *     .and("publishedYear").gte(2020)
+     *     .orderBy("title").asc()
+     *     .limit(10)
+     *     .result();
+     * }</pre>
+     *
+     * The returned instance is mutable and not thread-safe.
+     * Support for conditional composition, pagination, and ordering depends on
+     * the capabilities of the underlying NoSQL database.
      */
     interface MapperWhere extends MapperQueryBuild {
 
@@ -1215,10 +1565,22 @@ public interface QueryMapper {
         MapperLimit limit(long limit);
 
         /**
-         * Add the order how the result will return.
+         * Adds an ordering rule based on the specified column name.
+         * <p>
+         * Use this method to define how query results should be sorted.
+         * The sort direction (ascending or descending) is specified in
+         * the subsequent step.
+         * </p>
          *
-         * @param name the name to order
-         * @return a query with the sort defined
+         * <pre>{@code
+         * template.select(Book.class)
+         *     .where("author").eq("Ada")
+         *     .orderBy("title").asc()
+         *     .result();
+         * }</pre>
+         *
+         * @param name the column name to order by
+         * @return the {@link MapperOrder} instance for defining the sort direction
          * @throws NullPointerException when name is null
          */
         MapperOrder orderBy(String name);

--- a/api/src/main/java/jakarta/nosql/QueryMapper.java
+++ b/api/src/main/java/jakarta/nosql/QueryMapper.java
@@ -395,7 +395,7 @@ public interface QueryMapper {
          * @return the conditional step of the update fluent API
          * @throws NullPointerException when the field name is {@code null}
          */
-        MapperUpdateWhereStep where(String name);
+        MapperUpdateNameCondition where(String name);
     }
 
     /**
@@ -416,23 +416,23 @@ public interface QueryMapper {
      * This step is mutable and not thread-safe.
      * </p>
      */
-    interface MapperUpdateWhereStep {
+    interface MapperUpdateNameCondition {
 
         /**
          * Creates an update condition where the specified column name equals the provided value.
          * <pre>{@code
          * template.update(Book.class)
-         *         .set("published").to(true)
+         *         .set("publishMapperUpdateSetSteped").to(true)
          *         .where("author").eq("Ada")
          *         .execute();
          * }</pre>
          *
          * @param value the value for the condition
          * @param <T>   the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        <T> MapperDeleteWhere eq(T value);
+        <T> MapperUpdateWhere eq(T value);
 
         /**
          * Creates an update condition where the specified column matches the given pattern.
@@ -444,10 +444,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param value the pattern value for the condition
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        MapperDeleteWhere like(String value);
+        MapperUpdateWhere like(String value);
 
         /**
          * Creates an update condition where the specified column contains the given value.
@@ -459,10 +459,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param value the value for the condition
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        MapperDeleteWhere contains(String value);
+        MapperUpdateWhere contains(String value);
 
         /**
          * Creates an update condition where the specified column starts with the given value.
@@ -474,10 +474,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param value the prefix value for the condition
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        MapperDeleteWhere startsWith(String value);
+        MapperUpdateWhere startsWith(String value);
 
         /**
          * Creates an update condition where the specified column ends with the given value.
@@ -489,10 +489,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param value the suffix value for the condition
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        MapperDeleteWhere endsWith(String value);
+        MapperUpdateWhere endsWith(String value);
 
         /**
          * Creates an update condition where the specified column is greater than the provided value.
@@ -505,10 +505,10 @@ public interface QueryMapper {
          *
          * @param value the value for the condition
          * @param <T>   the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        <T> MapperDeleteWhere gt(T value);
+        <T> MapperUpdateWhere gt(T value);
 
         /**
          * Creates an update condition where the specified column is greater than or equal to the provided value.
@@ -521,10 +521,10 @@ public interface QueryMapper {
          *
          * @param value the value for the condition
          * @param <T>   the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        <T> MapperDeleteWhere gte(T value);
+        <T> MapperUpdateWhere gte(T value);
 
         /**
          * Creates an update condition where the specified column is less than the provided value.
@@ -537,10 +537,10 @@ public interface QueryMapper {
          *
          * @param value the value for the condition
          * @param <T>   the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        <T> MapperDeleteWhere lt(T value);
+        <T> MapperUpdateWhere lt(T value);
 
         /**
          * Creates an update condition where the specified column is less than or equal to the provided value.
@@ -553,10 +553,10 @@ public interface QueryMapper {
          *
          * @param value the value for the condition
          * @param <T>   the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when value is null
          */
-        <T> MapperDeleteWhere lte(T value);
+        <T> MapperUpdateWhere lte(T value);
 
         /**
          * Creates an update condition where the specified column is between the provided values.
@@ -570,10 +570,10 @@ public interface QueryMapper {
          * @param valueA the lower bound value
          * @param valueB the upper bound value
          * @param <T>    the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when any value is null
          */
-        <T> MapperDeleteWhere between(T valueA, T valueB);
+        <T> MapperUpdateWhere between(T valueA, T valueB);
 
         /**
          * Creates an update condition where the specified column value is contained in the provided values.
@@ -586,10 +586,10 @@ public interface QueryMapper {
          *
          * @param values the values for the condition
          * @param <T>    the type
-         * @return the {@link MapperDeleteWhere}
+         * @return the {@link MapperUpdateWhere}
          * @throws NullPointerException when values is null
          */
-        <T> MapperDeleteWhere in(Iterable<T> values);
+        <T> MapperUpdateWhere in(Iterable<T> values);
 
         /**
          * Negates the next update condition.
@@ -600,9 +600,15 @@ public interface QueryMapper {
          *         .execute();
          * }</pre>
          *
-         * @return the {@link MapperUpdateWhereStep}
+         * @return the {@link MapperUpdateNotCondition}
          */
-        MapperUpdateWhereStep not();
+        MapperUpdateNotCondition not();
+    }
+
+    /**
+        * Represents a NOT update condition in the fluent update API.
+     */
+    interface MapperUpdateNotCondition extends MapperUpdateNameCondition {
     }
 
     /**
@@ -612,7 +618,7 @@ public interface QueryMapper {
      * operators before executing the update operation.
      * </p>
      */
-    interface MapperUpdateConditionStep extends MapperUpdateQueryBuild {
+    interface MapperUpdateWhere extends MapperUpdateQueryBuild {
 
         /**
          * Adds an AND condition using the specified column name.
@@ -625,10 +631,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param name the column name for the condition
-         * @return the {@link MapperUpdateWhereStep}
+         * @return the {@link MapperUpdateNameCondition}
          * @throws NullPointerException when name is null
          */
-        MapperUpdateWhereStep and(String name);
+        MapperUpdateNameCondition and(String name);
 
         /**
          * Adds an OR condition using the specified column name.
@@ -641,10 +647,10 @@ public interface QueryMapper {
          * }</pre>
          *
          * @param name the column name for the condition
-         * @return the {@link MapperUpdateWhereStep}
+         * @return the {@link MapperUpdateNameCondition}
          * @throws NullPointerException when name is null
          */
-        MapperUpdateWhereStep or(String name);
+        MapperUpdateNameCondition or(String name);
 
     }
 

--- a/spec/src/main/asciidoc/chapters/api/template.adoc
+++ b/spec/src/main/asciidoc/chapters/api/template.adoc
@@ -48,7 +48,7 @@ System.out.println("The result " + optional);
 template.delete(Book.class, id);
 ----
 
-The `Template` class in Jakarta NoSQL simplifies CRUD (Create, Read, Update, Delete) operations by providing a fluent API for interacting with the underlying NoSQL database. This API allows developers to perform advanced queries and deletion operations beyond the basic ID attribute.
+The `Template` class in Jakarta NoSQL simplifies CRUD (Create, Read, Update, Delete) operations by providing a fluent API for interacting with the underlying NoSQL database. This API allows developers to perform advanced queries, update and deletion operations beyond the basic ID attribute.
 
 [source,java]
 ----
@@ -61,6 +61,15 @@ List<Book> books = template.select(Book.class)
         .and("edition")
         .gt(3)
         .result();
+
+template.update(Book.class)
+        .set("title")
+        .to("Efective Java - Third Edition")
+        .where("author")
+        .eq("Joshua Bloch")
+        .and("edition")
+        .gt(3)
+        .execute();
 
 template.delete(Book.class)
         .where("author")

--- a/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
@@ -20,7 +20,7 @@ of the project committers and various contributors.
 
 ==== Project Lead
 
-* https://projects.eclipse.org/content/otavio-santana-project-lead-jakarta-nosql[Otavio Santana,windows=\_blank]
+* https://accounts.eclipse.org/users/osantanatrg[Otavio Santana,windows=\_blank]
 
 ==== Contributors
 
@@ -30,23 +30,24 @@ of the project committers and various contributors.
 
 ==== Committers
 
-* https://projects.eclipse.org/content/andres-galante-committer-jakarta-nosql[Andres Galante,windows=\_blank]
-* https://projects.eclipse.org/content/fred-rowe-committer-jakarta-nosql[Fred Rowe,windows=\_blank]
-* https://projects.eclipse.org/content/gaurav-gupta-committer-jakarta-nosql[Gaurav Gupta,windows=\_blank]
-* https://projects.eclipse.org/content/ivan-junckes-filho-committer-jakarta-nosql[Ivan Junckes Filho,windows=\_blank]
-* https://projects.eclipse.org/content/jesse-gallagher-committer-jakarta-nosql[Jesse Gallagher,windows=\_blank]
-* https://projects.eclipse.org/content/michael-redlich-committer-jakarta-nosql[Michael Redlich,windows=\_blank]
-* https://projects.eclipse.org/content/nathan-rauh-committer-jakarta-nosql[Nathan Rauh,windows=\_blank]
-* https://projects.eclipse.org/content/otavio-santana-committer-jakarta-nosql[Otavio Santana,windows=\_blank]
-* https://projects.eclipse.org/content/werner-keil-committer-jakarta-nosql[Werner Keil,windows=\_blank]
+* https://accounts.eclipse.org/users/agalante[Andres Galante,windows=\_blank]
+* https://accounts.eclipse.org/users/[Fred Rowe,windows=\_blank]
+* https://accounts.eclipse.org/users/gguptael7[Gaurav Gupta,windows=\_blank]
+* https://accounts.eclipse.org/users/ijunckesfilho[Ivan Junckes Filho,windows=\_blank]
+* https://accounts.eclipse.org/users/jgallagher6v3[Jesse Gallagher,windows=\_blank]
+* https://accounts.eclipse.org/users/maxdearruda[Maximillian Arruda,windows=\_blank]
+* https://accounts.eclipse.org/users/mredlich[Michael Redlich,windows=\_blank]
+* https://accounts.eclipse.org/users/nrauhi2d[Nathan Rauh,windows=\_blank]
+* https://accounts.eclipse.org/users/osantanatrg[Otavio Santana,windows=\_blank]
+* https://accounts.eclipse.org/users/wkeil[Werner Keil,windows=\_blank]
 
 ==== Historical Committer
 
-* https://projects.eclipse.org/content/leonardo-lima-committer-jakarta-nosql[Leonardo Lima,windows=\_blank]
+* https://accounts.eclipse.org/users/llima4n3[Leonardo Lima,windows=\_blank]
 
 ==== Mentor
 
-* https://projects.eclipse.org/content/wayne-beaton-mentor-jakarta-nosql[Wayne Beaton,windows=\_blank]
+* https://accounts.eclipse.org/users/wbeaton[Wayne Beaton,windows=\_blank]
 
 ==== Full List of Contributors
 


### PR DESCRIPTION
This pull request introduces significant improvements to the update query API in Jakarta NoSQL, enhancing its clarity and consistency. The main changes involve renaming interfaces and methods to better reflect their purpose, updating return types for improved type safety, and expanding documentation. Additionally, there are updates to the project documentation, including improved examples and updated contributor links.

### API improvements to update query fluency

* Renamed `MapperUpdateWhereStep` to `MapperUpdateNameCondition`, and `MapperUpdateConditionStep` to `MapperUpdateWhere`, to clarify their roles in the fluent API. [[1]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L551-R551) [[2]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L762-R768)
* Changed method return types in the update condition API to consistently return the new `MapperUpdateWhere` and `MapperUpdateNameCondition` interfaces, improving type safety and fluency. [[1]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L520-R520) [[2]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L564-R567) [[3]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L579-R582) [[4]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L594-R597) [[5]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L609-R612) [[6]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L624-R627) [[7]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L640-R643) [[8]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L656-R659) [[9]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L672-R675) [[10]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L688-R691) [[11]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L705-R708) [[12]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L721-R724) [[13]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L775-R784) [[14]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L791-R800)
* Introduced the `MapperUpdateNotCondition` interface to represent NOT conditions in update queries, further improving the expressiveness of the API.

### Documentation and example enhancements

* Expanded the documentation to clarify that advanced update operations are supported, and added a code example demonstrating an update query using the fluent API. [[1]](diffhunk://#diff-71e29f5f0759449d57be5897bed0f978008dc1454e09e42ad0c9afc945cf37f2L51-R51) [[2]](diffhunk://#diff-71e29f5f0759449d57be5897bed0f978008dc1454e09e42ad0c9afc945cf37f2R65-R73)

### Project documentation updates

* Updated project lead and committer links to use Eclipse account URLs, added a missing committer, and updated the historical committer and mentor sections for accuracy. [[1]](diffhunk://#diff-e15c75edd6a95b94c5f7e3ec35b0cd365afc1d22a2b8e1820b23dcc71a860f88L23-R23) [[2]](diffhunk://#diff-e15c75edd6a95b94c5f7e3ec35b0cd365afc1d22a2b8e1820b23dcc71a860f88L33-R50)