### PR TITLE
Update release M2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -208,7 +208,7 @@ Optional<BudgetCar> result = template
 <dependency>
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql-api</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0-M2</version>
 </dependency>
 ----
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M2</version>
     </parent>
 
     <artifactId>jakarta.nosql-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0-M2</version>
     <packaging>pom</packaging>
 
     <name>Jakarta NoSQL</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M2</version>
     </parent>
 
     <artifactId>jakarta.nosql-spec</artifactId>
@@ -95,7 +95,7 @@
     		<plugin>
     			<groupId>org.eclipse.m2e</groupId>
     			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.1.0-SNAPSHOT</version>
+    			<version>1.1.0-M2</version>
     			<configuration>
     				<lifecycleMappingMetadata>
     					<pluginExecutions>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M2</version>
     </parent>
 
     <artifactId>jakarta.nosql-tck</artifactId>


### PR DESCRIPTION
This pull request updates the project to use the `1.1.0-M2` milestone release version of Jakarta NoSQL and related dependencies, replacing previous references to the `1.1.0-SNAPSHOT` or older versions. This ensures consistency across all modules and aligns the project with the latest milestone release.

Dependency and version updates:

* Updated the parent POM version to `1.1.0-M2` in the main `pom.xml`, `api/pom.xml`, `spec/pom.xml`, and `tck/pom.xml` files to ensure all modules inherit the correct version. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L23-R23) [[2]](diffhunk://#diff-f35103f068e191d5d8933637b2d4217d8f90a78728ccab1bada951a8d1c83590L16-R16) [[3]](diffhunk://#diff-850091365acdcdf5a1023a8b65788ae4a0d22b78684c8b9a3c0207fe9e520627L18-R18) [[4]](diffhunk://#diff-c7973ae892437cdc63d039ee91cf6d93bc035ba2f77d5cfaf8c326924b6ffa2dL18-R18)
* Updated the Jakarta NoSQL API dependency version to `1.1.0-M2` in the `README.adoc` to match the new release version for documentation and usage examples.
* Updated the `lifecycle-mapping` plugin version to `1.1.0-M2` in `spec/pom.xml` to maintain compatibility with the new parent version.