### PR TITLE
Fix less-than TCK assertion

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateInheritanceTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateInheritanceTest.java
@@ -40,14 +40,15 @@ public class SelectTemplateInheritanceTest extends AbstractTemplateTest {
         entities.forEach(entity -> template.insert(entity));
 
         try {
+            var upperBound = entities.getFirst().getAlcoholPercentage() + 1;
             var result = template.select(Drink.class)
                     .where("alcoholPercentage")
-                    .lt(entities.getFirst().getAlcoholPercentage() + 1)
+                    .lt(upperBound)
                     .<Drink>result();
 
             Assertions.assertThat(result)
                     .isNotEmpty()
-                    .allMatch(drink -> drink.getAlcoholPercentage() <= entities.getFirst().getAlcoholPercentage());
+                    .allMatch(drink -> drink.getAlcoholPercentage() < upperBound);
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }


### PR DESCRIPTION
 Fixes jakartaee/nosql#227.

Updates `SelectTemplateInheritanceTest.shouldInsertIterableAndSelectWithLessThanCondition` so the assertion matches the actual `.lt(...)` query threshold. The test queries for `alcoholPercentage < firstAlcoholPercentage + 1`, so the assertion should validate returned values against that same upper bound instead of `<= firstAlcoholPercentage`.