### PR TITLE
Generate graph api

### DIFF
--- a/communication-api/src/main/java/jakarta/nosql/communication/column/ColumnManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/column/ColumnManagerFactory.java
@@ -43,12 +43,17 @@ public interface ColumnManagerFactory {
 
 
     /**
-     * Returns the default {@link ColumnManager} associated
-     * with the underlying database implementation.
+     * Returns a {@link ColumnManager} associated with the
+     * provider-defined communication context.
      *
-     * <p>This method allows interaction with column-family
-     * databases that rely on provider-defined default
-     * communication contexts.</p>
+     * <p>The underlying database implementation determines
+     * how the column manager is resolved and configured.</p>
+     *
+     * <p>Depending on the provider implementation, the manager
+     * may be associated with a default column family,
+     * a configured namespace, an injected communication
+     * context, environment-based configuration,
+     * or provider-specific column structures.</p>
      *
      * <pre>{@code
      * ColumnManagerFactory factory = ...
@@ -56,7 +61,12 @@ public interface ColumnManagerFactory {
      * ColumnManager manager = factory.get();
      * }</pre>
      *
-     * @return the default column manager
+     * @return the column manager associated with the
+     * provider-defined communication context
+     * @throws IllegalStateException when the provider
+     * cannot resolve a communication context or when
+     * the underlying configuration is incomplete
+     * or invalid
      */
     ColumnManager get();
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/document/DocumentManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/document/DocumentManagerFactory.java
@@ -43,12 +43,17 @@ package jakarta.nosql.communication.document;
 public interface DocumentManagerFactory {
 
     /**
-     * Returns the default {@link DocumentManager} associated
-     * with the underlying database implementation.
+     * Returns a {@link DocumentManager} associated with the
+     * provider-defined communication context.
      *
-     * <p>This method allows interaction with document databases
-     * that rely on provider-defined default communication
-     * contexts.</p>
+     * <p>The underlying database implementation determines
+     * how the document manager is resolved and configured.</p>
+     *
+     * <p>Depending on the provider implementation, the manager
+     * may be associated with a default collection,
+     * a configured namespace, an injected communication
+     * context, environment-based configuration,
+     * or provider-specific document structures.</p>
      *
      * <pre>{@code
      * DocumentManagerFactory factory = ...
@@ -56,7 +61,12 @@ public interface DocumentManagerFactory {
      * DocumentManager manager = factory.get();
      * }</pre>
      *
-     * @return the default document manager
+     * @return the document manager associated with the
+     * provider-defined communication context
+     * @throws IllegalStateException when the provider
+     * cannot resolve a communication context or when
+     * the underlying configuration is incomplete
+     * or invalid
      */
     DocumentManager get();
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
@@ -39,4 +39,43 @@ package jakarta.nosql.communication.graph;
  * consistency strategies.</p>
  */
 public interface Edge extends GraphElement {
+
+
+    /**
+     * Returns the source vertex identifier associated
+     * with this edge.
+     *
+     * <p>The interpretation and structure of the identifier
+     * are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * Edge edge = ...
+     *
+     * String source = edge.source();
+     * }</pre>
+     *
+     * @param <K> the identifier type
+     * @return the source vertex identifier
+     */
+    <K> K source();
+
+    /**
+     * Returns the target vertex identifier associated
+     * with this edge.
+     *
+     * <p>The interpretation and structure of the identifier
+     * are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * Edge edge = ...
+     *
+     * String target = edge.target();
+     * }</pre>
+     *
+     * @param <K> the identifier type
+     * @return the target vertex identifier
+     */
+    <K> K target();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
@@ -15,5 +15,28 @@
  */
 package jakarta.nosql.communication.graph;
 
-public interface Edge {
+/**
+ * Represents a relationship between two vertices within
+ * a graph database.
+ *
+ * <p>An {@code Edge} defines a graph-native structure used
+ * to represent connections, associations, or relationships
+ * between vertices according to the semantics of the
+ * underlying database implementation.</p>
+ *
+ * <p>Edges commonly contain relationship types, properties,
+ * direction semantics, metadata, or provider-specific
+ * structures associated with graph connectivity.</p>
+ *
+ * <p>The interpretation, visibility guarantees, durability
+ * semantics, consistency model, serialization strategy,
+ * connectivity behavior, and execution semantics associated
+ * with edges are determined by the provider implementation.</p>
+ *
+ * <p>Implementations may support additional capabilities such
+ * as typed relationships, graph partitioning, distributed
+ * graph storage, provider-specific metadata, or eventual
+ * consistency strategies.</p>
+ */
+public interface Edge extends GraphElement {
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
@@ -40,6 +40,21 @@ package jakarta.nosql.communication.graph;
  */
 public interface Edge extends GraphElement {
 
+    /**
+     * Returns the relationship type associated with this edge.
+     *
+     * <p>The interpretation and semantics of the type are
+     * determined by the underlying database implementation.</p>
+     *
+     * <pre>{@code
+     * Edge edge = ...
+     *
+     * String type = edge.type();
+     * }</pre>
+     *
+     * @return the relationship type
+     */
+    String type();
 
     /**
      * Returns the source vertex identifier associated

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package jakarta.nosql.communication.graph;
 
 public interface Edge {

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Edge.java
@@ -1,0 +1,4 @@
+package jakarta.nosql.communication.graph;
+
+public interface Edge {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -40,4 +40,21 @@ package jakarta.nosql.communication.graph;
  * consistency strategies.</p>
  */
 public interface GraphElement {
+
+    /**
+     * Returns the graph element identifier.
+     *
+     * <p>The interpretation and structure of the identifier
+     * are determined by the underlying database implementation.</p>
+     *
+     * <pre>{@code
+     * GraphElement element = ...
+     *
+     * String id = element.id();
+     * }</pre>
+     *
+     * @param <K> the identifier type
+     * @return the graph element identifier
+     */
+    <K> K id();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -16,6 +16,7 @@
 package jakarta.nosql.communication.graph;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a graph element within a graph database.
@@ -79,6 +80,31 @@ public interface GraphElement {
      * @return the graph element properties
      */
     List<Property> properties();
+
+    /**
+     * Returns the value associated with the provided property.
+     *
+     * <p>The interpretation, serialization strategy, and
+     * visibility semantics associated with property values
+     * are determined by the underlying database implementation.</p>
+     *
+     * <p>If the property does not exist, this method returns
+     * an empty {@link Optional}.</p>
+     *
+     * <pre>{@code
+     * GraphElement element = ...
+     *
+     * Optional<String> name =
+     *         element.get("name");
+     * }</pre>
+     *
+     * @param property the property name
+     * @param <T> the property value type
+     * @return the property value when present,
+     * otherwise an empty {@link Optional}
+     * @throws NullPointerException when the property is {@code null}
+     */
+    <T> Optional<T> get(String property);
 
 
     /**

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -15,5 +15,29 @@
  */
 package jakarta.nosql.communication.graph;
 
-public class GraphElement {
+/**
+ * Represents a graph element within a graph database.
+ *
+ * <p>A {@code GraphElement} defines the minimal communication
+ * structure shared by graph-oriented database elements such
+ * as vertices and edges.</p>
+ *
+ * <p>Graph databases commonly organize data using connected
+ * structures composed of vertices, relationships, labels,
+ * and properties. Graph elements expose properties associated
+ * with graph-native structures according to the semantics of
+ * the underlying database implementation.</p>
+ *
+ * <p>The interpretation, visibility guarantees, durability
+ * semantics, consistency model, serialization strategy,
+ * identity model, and execution behavior associated with
+ * graph elements are determined by the provider
+ * implementation.</p>
+ *
+ * <p>Implementations may support additional capabilities such
+ * as labels, typed relationships, distributed graph storage,
+ * provider-specific metadata, graph partitioning, or eventual
+ * consistency strategies.</p>
+ */
+public interface GraphElement {
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package jakarta.nosql.communication.graph;
 
 public class GraphElement {

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -1,0 +1,4 @@
+package jakarta.nosql.communication.graph;
+
+public class GraphElement {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -15,6 +15,8 @@
  */
 package jakarta.nosql.communication.graph;
 
+import java.util.List;
+
 /**
  * Represents a graph element within a graph database.
  *
@@ -57,4 +59,24 @@ public interface GraphElement {
      * @return the graph element identifier
      */
     <K> K id();
+
+
+    /**
+     * Returns the properties associated with this graph element.
+     *
+     * <p>The organization, visibility semantics, ordering
+     * guarantees, and property structure are determined by
+     * the underlying database implementation.</p>
+     *
+     * <pre>{@code
+     * GraphElement element = ...
+     *
+     * for (Property property : element.properties()) {
+     *     System.out.println(property.name());
+     * }
+     * }</pre>
+     *
+     * @return the graph element properties
+     */
+    List<Property> properties();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphElement.java
@@ -79,4 +79,25 @@ public interface GraphElement {
      * @return the graph element properties
      */
     List<Property> properties();
+
+
+    /**
+     * Returns whether this graph element contains the
+     * provided property.
+     *
+     * <p>The existence semantics associated with properties
+     * are determined by the underlying database implementation.</p>
+     *
+     * <pre>{@code
+     * GraphElement element = ...
+     *
+     * boolean contains = element.contains("name");
+     * }</pre>
+     *
+     * @param property the property name
+     * @return {@code true} when the property exists,
+     * otherwise {@code false}
+     * @throws NullPointerException when the property is {@code null}
+     */
+    boolean contains(String property);
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -80,7 +80,38 @@ public interface GraphManager {
      */
     Vertex put(Vertex vertex);
 
+    /**
+     * Stores an edge in the graph database.
+     *
+     * <p>This operation behaves according to the semantics
+     * of the underlying database implementation.</p>
+     *
+     * <p>When the edge identifier does not exist,
+     * the operation may behave as an insertion. When the
+     * identifier already exists, the existing edge may
+     * be replaced, merged, updated, or synchronized
+     * according to the provider implementation.</p>
+     *
+     * <p>The visibility guarantees, durability semantics,
+     * consistency model, graph synchronization behavior,
+     * connectivity semantics, and execution timing
+     * associated with this operation are determined by
+     * the provider implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * Edge edge = ...
+     *
+     * Edge stored = manager.put(edge);
+     * }</pre>
+     *
+     * @param edge the edge to store
+     * @return the stored edge instance
+     * @throws NullPointerException when the edge is {@code null}
+     */
     Edge put(Edge edge);
+
 
     Optional<Vertex> findVertexById(Object id);
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package jakarta.nosql.communication.graph;
 
 import java.util.Optional;

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -49,6 +49,35 @@ import java.util.Optional;
  */
 public interface GraphManager {
 
+    /**
+     * Stores a vertex in the graph database.
+     *
+     * <p>This operation behaves according to the semantics
+     * of the underlying database implementation.</p>
+     *
+     * <p>When the vertex identifier does not exist,
+     * the operation may behave as an insertion. When the
+     * identifier already exists, the existing vertex may
+     * be replaced, merged, updated, or synchronized
+     * according to the provider implementation.</p>
+     *
+     * <p>The visibility guarantees, durability semantics,
+     * consistency model, graph synchronization behavior,
+     * and execution timing associated with this operation
+     * are determined by the provider implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * Vertex vertex = ...
+     *
+     * Vertex stored = manager.put(vertex);
+     * }</pre>
+     *
+     * @param vertex the vertex to store
+     * @return the stored vertex instance
+     * @throws NullPointerException when the vertex is {@code null}
+     */
     Vertex put(Vertex vertex);
 
     Edge put(Edge edge);

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -1,4 +1,17 @@
 package jakarta.nosql.communication.graph;
 
 public class GraphManager {
+
+    Vertex put(Vertex vertex);
+
+    Edge put(Edge edge);
+
+    Optional<Vertex> findVertexById(Object id);
+
+    Optional<Edge> findEdgeById(Object id);
+
+    void deleteVertexById(Object id);
+
+    void deleteEdgeById(Object id);
+
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -1,6 +1,8 @@
 package jakarta.nosql.communication.graph;
 
-public class GraphManager {
+import java.util.Optional;
+
+public interface GraphManager {
 
     Vertex put(Vertex vertex);
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -135,7 +135,29 @@ public interface GraphManager {
      */
     <K> Optional<Vertex> findVertexById(K id);
 
-    Optional<Edge> findEdgeById(Object id);
+    /**
+     * Returns the edge associated with the provided identifier.
+     *
+     * <p>The interpretation and structure of the identifier
+     * are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * Optional<Edge> edge =
+     *         manager.findEdgeById("edge:10");
+     * }</pre>
+     *
+     * @param id the edge identifier
+     * @param <K> the identifier type
+     * @return the edge associated with the identifier,
+     * otherwise an empty {@link Optional}
+     * @throws NullPointerException when the identifier
+     * is {@code null}
+     */
+    <K> Optional<Edge> findEdgeById(K id);
+
 
     void deleteVertexById(Object id);
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -185,6 +185,25 @@ public interface GraphManager {
      */
     <K> void deleteVertexById(K id);
 
-    void deleteEdgeById(Object id);
+    /**
+     * Requests the removal of an edge using its identifier.
+     *
+     * <p>The visibility guarantees, graph synchronization
+     * semantics, durability semantics, consistency model,
+     * and execution timing associated with this operation
+     * are determined by the provider implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * manager.deleteEdgeById("edge:10");
+     * }</pre>
+     *
+     * @param id the edge identifier
+     * @param <K> the identifier type
+     * @throws NullPointerException when the identifier
+     * is {@code null}
+     */
+    <K> void deleteEdgeById(K id);
 
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -158,8 +158,32 @@ public interface GraphManager {
      */
     <K> Optional<Edge> findEdgeById(K id);
 
-
-    void deleteVertexById(Object id);
+    /**
+     * Requests the removal of a vertex using its identifier.
+     *
+     * <p>The visibility guarantees, graph synchronization
+     * semantics, relationship consistency behavior,
+     * durability semantics, and execution timing associated
+     * with this operation are determined by the provider
+     * implementation.</p>
+     *
+     * <p>Depending on the underlying database implementation,
+     * removing a vertex may affect associated edges,
+     * relationships, graph connectivity, or provider-specific
+     * graph structures.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * manager.deleteVertexById("user:10");
+     * }</pre>
+     *
+     * @param id the vertex identifier
+     * @param <K> the identifier type
+     * @throws NullPointerException when the identifier
+     * is {@code null}
+     */
+    <K> void deleteVertexById(K id);
 
     void deleteEdgeById(Object id);
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -112,8 +112,28 @@ public interface GraphManager {
      */
     Edge put(Edge edge);
 
-
-    Optional<Vertex> findVertexById(Object id);
+    /**
+     * Returns the vertex associated with the provided identifier.
+     *
+     * <p>The interpretation and structure of the identifier
+     * are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManager manager = ...
+     *
+     * Optional<Vertex> vertex =
+     *         manager.findVertexById("user:10");
+     * }</pre>
+     *
+     * @param id the vertex identifier
+     * @param <K> the identifier type
+     * @return the vertex associated with the identifier,
+     * otherwise an empty {@link Optional}
+     * @throws NullPointerException when the identifier
+     * is {@code null}
+     */
+    <K> Optional<Vertex> findVertexById(K id);
 
     Optional<Edge> findEdgeById(Object id);
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -17,6 +17,36 @@ package jakarta.nosql.communication.graph;
 
 import java.util.Optional;
 
+/**
+ * Defines the communication contract for interacting with
+ * graph databases.
+ *
+ * <p>A {@code GraphManager} provides lifecycle operations
+ * for graph-native structures such as {@link Vertex}
+ * and {@link Edge}.</p>
+ *
+ * <p>Graph databases commonly organize data using connected
+ * structures composed of vertices, relationships, labels,
+ * properties, and provider-specific graph semantics.</p>
+ *
+ * <p>The visibility guarantees, durability semantics,
+ * consistency model, graph partitioning behavior,
+ * replication strategies, connectivity semantics,
+ * and execution timing associated with operations are
+ * determined by the provider implementation.</p>
+ *
+ * <p>This interface intentionally avoids introducing
+ * traversal APIs, graph query languages, path semantics,
+ * graph algorithms, or provider-specific navigation
+ * capabilities beyond the minimal lifecycle operations
+ * defined by the Communication API.</p>
+ *
+ * <p>Implementations may support additional capabilities
+ * such as distributed graph storage, typed relationships,
+ * provider-specific metadata, graph partitioning,
+ * replication optimizations, or eventual consistency
+ * strategies.</p>
+ */
 public interface GraphManager {
 
     Vertex put(Vertex vertex);

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManager.java
@@ -1,0 +1,4 @@
+package jakarta.nosql.communication.graph;
+
+public class GraphManager {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -15,5 +15,30 @@
  */
 package jakarta.nosql.communication.graph;
 
+/**
+ * Creates {@link GraphManager} instances for graph database
+ * communication.
+ *
+ * <p>A {@code GraphManagerFactory} is an entry point to the
+ * graph portion of the Jakarta NoSQL Communication API.
+ * It provides access to managers associated with logical
+ * graph structures according to the behavior of the
+ * underlying database implementation.</p>
+ *
+ * <p>Depending on the provider implementation, names may
+ * represent concepts such as graphs, namespaces,
+ * logical graph groups, databases, or provider-specific
+ * graph structures.</p>
+ *
+ * <p>The configuration, initialization, caching behavior,
+ * lifecycle semantics, visibility guarantees, and manager
+ * creation strategies are determined by the provider
+ * implementation.</p>
+ *
+ * <p>Providers may configure managers using mechanisms such
+ * as Java properties, environment variables, configuration
+ * files, dependency injection, or provider-specific
+ * strategies.</p>
+ */
 public interface GraphManagerFactory {
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package jakarta.nosql.communication.graph;
 
 public interface GraphManagerFactory {

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -1,0 +1,4 @@
+package jakarta.nosql.communication.graph;
+
+public interface GraphManagerFactory {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -63,6 +63,10 @@ public interface GraphManagerFactory {
      *
      * @return the graph manager associated with the
      * provider-defined communication context
+     * @throws IllegalStateException when the provider
+     * cannot resolve a communication context or when
+     * the underlying configuration is incomplete
+     * or invalid
      */
     GraphManager get();
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -59,4 +59,26 @@ public interface GraphManagerFactory {
      * @return the default graph manager
      */
     GraphManager get();
+
+
+    /**
+     * Returns a {@link GraphManager} associated with the
+     * provided logical name.
+     *
+     * <p>The interpretation and semantics of the provided
+     * name are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * GraphManagerFactory factory = ...
+     *
+     * GraphManager manager =
+     *         factory.get("social");
+     * }</pre>
+     *
+     * @param name the logical name associated with the manager
+     * @return the graph manager associated with the provided name
+     * @throws NullPointerException when the name is {@code null}
+     */
+    GraphManager get(String name);
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -43,12 +43,17 @@ package jakarta.nosql.communication.graph;
 public interface GraphManagerFactory {
 
     /**
-     * Returns the default {@link GraphManager} associated
-     * with the underlying database implementation.
+     * Returns a {@link GraphManager} associated with the
+     * provider-defined communication context.
      *
-     * <p>This method allows interaction with graph databases
-     * that rely on provider-defined default communication
-     * contexts.</p>
+     * <p>The underlying database implementation determines
+     * how the graph manager is resolved and configured.</p>
+     *
+     * <p>Depending on the provider implementation, the manager
+     * may be associated with a default graph, a configured
+     * namespace, an injected communication context,
+     * environment-based configuration, or provider-specific
+     * graph structures.</p>
      *
      * <pre>{@code
      * GraphManagerFactory factory = ...
@@ -56,7 +61,8 @@ public interface GraphManagerFactory {
      * GraphManager manager = factory.get();
      * }</pre>
      *
-     * @return the default graph manager
+     * @return the graph manager associated with the
+     * provider-defined communication context
      */
     GraphManager get();
 

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/GraphManagerFactory.java
@@ -41,4 +41,22 @@ package jakarta.nosql.communication.graph;
  * strategies.</p>
  */
 public interface GraphManagerFactory {
+
+    /**
+     * Returns the default {@link GraphManager} associated
+     * with the underlying database implementation.
+     *
+     * <p>This method allows interaction with graph databases
+     * that rely on provider-defined default communication
+     * contexts.</p>
+     *
+     * <pre>{@code
+     * GraphManagerFactory factory = ...
+     *
+     * GraphManager manager = factory.get();
+     * }</pre>
+     *
+     * @return the default graph manager
+     */
+    GraphManager get();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
@@ -1,0 +1,4 @@
+package jakarta.nosql.communication.graph;
+
+public interface Property {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
@@ -1,4 +1,9 @@
 package jakarta.nosql.communication.graph;
 
 public interface Property {
+
+    String name();
+
+    <T> T value();
+
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
@@ -15,6 +15,23 @@
  */
 package jakarta.nosql.communication.graph;
 
+/**
+ * Represents a property associated with a graph element.
+ *
+ * <p>A {@code Property} defines the association between a
+ * property name and its corresponding value according to
+ * the semantics of the underlying graph database
+ * implementation.</p>
+ *
+ * <p>Graph databases commonly associate properties with
+ * nodes and relationships to describe attributes,
+ * metadata, labels, or provider-specific information.</p>
+ *
+ * <p>The interpretation, visibility guarantees, durability
+ * semantics, consistency model, serialization strategy,
+ * and execution behavior associated with properties are
+ * determined by the provider implementation.</p>
+ */
 public interface Property {
 
     String name();

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package jakarta.nosql.communication.graph;
 
 public interface Property {

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Property.java
@@ -34,8 +34,40 @@ package jakarta.nosql.communication.graph;
  */
 public interface Property {
 
+    /**
+     * Returns the property name.
+     *
+     * <pre>{@code
+     * Property property = ...
+     *
+     * String name = property.name();
+     * }</pre>
+     *
+     * @return the property name
+     */
     String name();
 
+    /**
+     * Returns the property value.
+     *
+     * <p>The returned value may represent different data
+     * types according to the serialization and storage
+     * semantics of the underlying database implementation.</p>
+     *
+     * <p>Depending on the provider implementation, the value
+     * may represent primitive values, collections,
+     * provider-specific structures, or graph-native
+     * representations.</p>
+     *
+     * <pre>{@code
+     * Property property = ...
+     *
+     * String value = property.value();
+     * }</pre>
+     *
+     * @param <T> the value type
+     * @return the property value
+     */
     <T> T value();
 
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.nosql.communication.graph;
+
+public interface Vertex {
+}

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
@@ -40,4 +40,40 @@ package jakarta.nosql.communication.graph;
  * strategies.</p>
  */
 public interface Vertex {
+
+    /**
+     * Returns the logical label associated with this vertex.
+     *
+     * <p>The interpretation and semantics of the label are
+     * determined by the underlying database implementation.</p>
+     *
+     * <pre>{@code
+     * Vertex vertex = ...
+     *
+     * String label = vertex.label();
+     * }</pre>
+     *
+     * @return the vertex label
+     */
+    String label();
+
+    /**
+     * Returns the edges associated with this vertex.
+     *
+     * <p>The organization, direction semantics, visibility
+     * guarantees, connectivity behavior, and relationship
+     * structure are determined by the underlying database
+     * implementation.</p>
+     *
+     * <pre>{@code
+     * Vertex vertex = ...
+     *
+     * for (Edge edge : vertex.edges()) {
+     *     System.out.println(edge.type());
+     * }
+     * }</pre>
+     *
+     * @return the vertex edges
+     */
+    List<Edge> edges();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
@@ -15,5 +15,29 @@
  */
 package jakarta.nosql.communication.graph;
 
+/**
+ * Represents a vertex within a graph database.
+ *
+ * <p>A {@code Vertex} defines a graph-native structure used
+ * to represent entities, nodes, or connected elements within
+ * a graph model.</p>
+ *
+ * <p>Vertices are commonly connected through relationships
+ * represented by {@link Edge} instances and may contain
+ * labels, properties, metadata, or provider-specific
+ * structures according to the semantics of the underlying
+ * database implementation.</p>
+ *
+ * <p>The interpretation, visibility guarantees, durability
+ * semantics, consistency model, serialization strategy,
+ * connectivity behavior, and execution semantics associated
+ * with vertices are determined by the provider
+ * implementation.</p>
+ *
+ * <p>Implementations may support additional capabilities such
+ * as labels, graph partitioning, distributed graph storage,
+ * provider-specific metadata, or eventual consistency
+ * strategies.</p>
+ */
 public interface Vertex {
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/Vertex.java
@@ -57,23 +57,4 @@ public interface Vertex {
      */
     String label();
 
-    /**
-     * Returns the edges associated with this vertex.
-     *
-     * <p>The organization, direction semantics, visibility
-     * guarantees, connectivity behavior, and relationship
-     * structure are determined by the underlying database
-     * implementation.</p>
-     *
-     * <pre>{@code
-     * Vertex vertex = ...
-     *
-     * for (Edge edge : vertex.edges()) {
-     *     System.out.println(edge.type());
-     * }
-     * }</pre>
-     *
-     * @return the vertex edges
-     */
-    List<Edge> edges();
 }

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -1,0 +1,1 @@
+package jakarta.nosql.communication.graph;

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -1,1 +1,17 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package jakarta.nosql.communication.graph;

--- a/communication-api/src/main/java/jakarta/nosql/communication/keyvalue/BucketManagerFactory.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/keyvalue/BucketManagerFactory.java
@@ -53,16 +53,18 @@ public interface BucketManagerFactory {
     BucketManager get(String bucket);
 
     /**
-     * Returns the default {@link BucketManager} associated with
-     * the underlying database implementation.
+     * Returns a {@link BucketManager} associated with the
+     * provider-defined communication context.
      *
-     * <p>This method allows interaction with key-value databases
-     * that do not expose bucket concepts directly or rely on
-     * provider-defined default communication contexts.</p>
+     * <p>The underlying database implementation determines
+     * how the bucket manager is resolved and configured.</p>
      *
-     * <p>Implementations may interpret the default manager using
-     * provider-specific strategies such as namespaces, key prefixes,
-     * configuration defaults, or logical grouping mechanisms.</p>
+     * <p>Depending on the provider implementation, the manager
+     * may be associated with a default bucket, a configured
+     * namespace, an injected communication context,
+     * environment-based configuration, key prefixes,
+     * logical grouping mechanisms, or provider-specific
+     * key-value structures.</p>
      *
      * <pre>{@code
      * BucketManagerFactory factory = ...
@@ -70,7 +72,12 @@ public interface BucketManagerFactory {
      * BucketManager manager = factory.get();
      * }</pre>
      *
-     * @return the default bucket manager
+     * @return the bucket manager associated with the
+     * provider-defined communication context
+     * @throws IllegalStateException when the provider
+     * cannot resolve a communication context or when
+     * the underlying configuration is incomplete
+     * or invalid
      */
     BucketManager get();
 }


### PR DESCRIPTION
This pull request introduces a new graph database communication API to the project, alongside improvements to the documentation of existing column and document manager factories. The new API defines interfaces for graph elements, properties, edges, vertices, and managers, providing a foundation for interacting with graph databases in a provider-agnostic way.

The most important changes are:

**New Graph Database Communication API:**

* Added `GraphElement` interface to represent the minimal structure shared by graph database elements, including methods for accessing properties and identifiers.
* Added `Property` interface to represent a name-value pair associated with a graph element.
* Added `Edge` interface to represent relationships between vertices in a graph, including methods for relationship type and source/target identifiers.
* Added `GraphManager` interface to provide lifecycle operations (CRUD) for vertices and edges in a graph database.
* Added `GraphManagerFactory` interface to create `GraphManager` instances, including support for provider-defined communication contexts and named graphs.

**Improvements to Manager Factory Documentation:**

* Enhanced Javadoc for `ColumnManagerFactory#get()` and `DocumentManagerFactory#get()` to clarify provider-defined context resolution, configuration, and error handling, making the API behavior more explicit for users. [[1]](diffhunk://#diff-8d4dfff3fdf8f47d8ca4d0c5ed4168c3d2d2b89b8627eaaddc5235e9d94e2e5dL46-R69) [[2]](diffhunk://#diff-b53eeef80ab47e340172f30a01f2d87ca7a2a701bbca200bc98ddeb3a3715c8bL46-R69)