### PR TITLE
Enhance documentation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Include Query interface
 - include TypedQuery interface
 - Include Fluent API to Update operations
+- Introduce Communication API
 
 == [1.0.1] - 2025-07-01
 

--- a/README.adoc
+++ b/README.adoc
@@ -207,8 +207,6 @@ The Communication API defines a minimal and extensible foundation for interactin
 
 The API focuses on low-level lifecycle operations such as storing, retrieving, replacing, and removing data structures according to the capabilities and characteristics of the target database.
 
-Rather than introducing a universal abstraction over all NoSQL systems, the Communication API embraces the diversity of NoSQL databases by providing specialized communication models aligned with their native structures and operational semantics.
-
 The Communication API is intentionally designed to support:
 
 * Minimal abstraction
@@ -217,9 +215,8 @@ The Communication API is intentionally designed to support:
 * Preservation of native database semantics
 * Low-level communication operations
 
-Depending on the provider implementation, communication operations may support capabilities such as distributed replication, eventual consistency, partitioning, batching optimizations, append-oriented persistence, graph connectivity semantics, or provider-specific communication behaviors.
+Communication managers may be configured using mechanisms such as Java properties, environment variables, dependency injection, configuration files, or provider-specific communication contexts according to the underlying database implementation.
 
-Providers may configure communication managers using mechanisms such as Java properties, environment variables, dependency injection, configuration files, provider-defined defaults, or provider-specific communication contexts.
 
 === Maven dependency
 

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,17 @@ manager.deleteByKey("user:10");
 ----
 
 
+Document records expose document elements through named structures.
+
+[source,java]
+----
+DocumentRecord record = ...
+
+Optional<String> name = record.get("name");
+----
+
+
+
 === Maven dependency
 
 [source,xml]

--- a/README.adoc
+++ b/README.adoc
@@ -217,6 +217,20 @@ The Communication API is intentionally designed to support:
 
 Communication managers may be configured using mechanisms such as Java properties, environment variables, dependency injection, configuration files, or provider-specific communication contexts according to the underlying database implementation.
 
+=== Key-Value
+
+The key-value communication model represents interaction with NoSQL databases based on the association of a unique key to a value.
+
+[source,java]
+----
+BucketManagerFactory factory = ...
+BucketManager manager = factory.get("users");
+KeyValueRecord record = ...
+
+manager.put(record);
+Optional<KeyValueRecord> result = manager.findByKey("user:10");
+manager.deleteByKey("user:10");
+----
 
 === Maven dependency
 

--- a/README.adoc
+++ b/README.adoc
@@ -232,6 +232,26 @@ Optional<KeyValueRecord> result = manager.findByKey("user:10");
 manager.deleteByKey("user:10");
 ----
 
+=== Document
+
+The document communication model represents interaction with NoSQL databases based on hierarchical and nested document structures.
+
+[source,java]
+----
+DocumentManagerFactory factory = ...
+
+DocumentManager manager = factory.get("users");
+
+DocumentRecord record = ...
+
+manager.put(record);
+
+Optional<DocumentRecord> result = manager.findByKey("user:10");
+
+manager.deleteByKey("user:10");
+----
+
+
 === Maven dependency
 
 [source,xml]

--- a/README.adoc
+++ b/README.adoc
@@ -284,6 +284,36 @@ ColumnRecord record = ...
 Optional<String> name = record.get("name");
 ----
 
+=== Graph
+
+The graph communication model represents interaction with graph-oriented NoSQL databases based on connected structures composed of vertices, edges, and properties.
+
+[source,java]
+----
+GraphManagerFactory factory = ...
+
+GraphManager manager = factory.get("social");
+
+Vertex vertex = ...
+
+manager.put(vertex);
+
+Optional<Vertex> result = manager.findVertexById("user:10");
+
+manager.deleteVertexById("user:10");
+----
+
+Edges represent relationships between vertices according to the semantics of the underlying database implementation.
+
+[source,java]
+----
+Edge edge = ...
+
+String type = edge.type();
+String source = edge.source();
+String target = edge.target();
+----
+
 === Maven dependency
 
 [source,xml]

--- a/README.adoc
+++ b/README.adoc
@@ -261,7 +261,28 @@ DocumentRecord record = ...
 Optional<String> name = record.get("name");
 ----
 
+=== Column
 
+The column-family communication model represents interaction with NoSQL databases based on sparse and partition-oriented column structures.
+
+[source,java]
+----
+ColumnManagerFactory factory = ...
+ColumnManager manager = factory.get("users");
+ColumnRecord record = ...
+
+manager.put(record);
+Optional<ColumnRecord> result = manager.findByKey("user:10");
+manager.deleteByKey("user:10");
+----
+
+Column records expose sparse collections of columns associated with a logical record structure.
+
+[source,java]
+----
+ColumnRecord record = ...
+Optional<String> name = record.get("name");
+----
 
 === Maven dependency
 

--- a/README.adoc
+++ b/README.adoc
@@ -201,7 +201,7 @@ Optional<BudgetCar> result = template
     .singleResult();
 ----
 
-=== What is the Communication API and the Goal
+=== Communication API
 
 The Communication API defines a minimal and extensible foundation for interacting with NoSQL databases while preserving the native semantics and operational behavior of the underlying database implementation.
 
@@ -220,7 +220,6 @@ The Communication API is intentionally designed to support:
 Depending on the provider implementation, communication operations may support capabilities such as distributed replication, eventual consistency, partitioning, batching optimizations, append-oriented persistence, graph connectivity semantics, or provider-specific communication behaviors.
 
 Providers may configure communication managers using mechanisms such as Java properties, environment variables, dependency injection, configuration files, provider-defined defaults, or provider-specific communication contexts.
-
 
 === Maven dependency
 

--- a/README.adoc
+++ b/README.adoc
@@ -201,6 +201,27 @@ Optional<BudgetCar> result = template
     .singleResult();
 ----
 
+=== What is the Communication API and the Goal
+
+The Communication API defines a minimal and extensible foundation for interacting with NoSQL databases while preserving the native semantics and operational behavior of the underlying database implementation.
+
+The API focuses on low-level lifecycle operations such as storing, retrieving, replacing, and removing data structures according to the capabilities and characteristics of the target database.
+
+Rather than introducing a universal abstraction over all NoSQL systems, the Communication API embraces the diversity of NoSQL databases by providing specialized communication models aligned with their native structures and operational semantics.
+
+The Communication API is intentionally designed to support:
+
+* Minimal abstraction
+* Provider neutrality
+* Extensibility
+* Preservation of native database semantics
+* Low-level communication operations
+
+Depending on the provider implementation, communication operations may support capabilities such as distributed replication, eventual consistency, partitioning, batching optimizations, append-oriented persistence, graph connectivity semantics, or provider-specific communication behaviors.
+
+Providers may configure communication managers using mechanisms such as Java properties, environment variables, dependency injection, configuration files, provider-defined defaults, or provider-specific communication contexts.
+
+
 === Maven dependency
 
 [source,xml]

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -55,8 +55,7 @@
  * <pre>{@code
  * Vertex vertex = ...
  *
- * Optional<String> name =
- *         vertex.get("name");
+ * Optional<String> name = vertex.get("name");
  * }</pre>
  *
  * <p>This model intentionally avoids introducing traversal

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -14,4 +14,76 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
+/**
+ * Provides the graph communication model for Jakarta NoSQL.
+ *
+ * <p>The graph communication model represents interaction
+ * with graph-oriented NoSQL databases based on connected
+ * structures composed of vertices, edges, and properties.</p>
+ *
+ * <p>The APIs defined in this package provide a minimal and
+ * extensible communication structure aligned with the native
+ * behavior of graph databases:</p>
+ *
+ * <pre>{@code
+ * GraphManagerFactory factory = ...
+ *
+ * GraphManager manager = factory.get("social");
+ *
+ * Vertex vertex = ...
+ *
+ * manager.put(vertex);
+ *
+ * Optional<Vertex> result =
+ *         manager.findVertexById("user:10");
+ *
+ * manager.deleteVertexById("user:10");
+ * }</pre>
+ *
+ * <p>Edges represent relationships between vertices according
+ * to the semantics of the underlying database implementation:</p>
+ *
+ * <pre>{@code
+ * Edge edge = ...
+ *
+ * String type = edge.type();
+ *
+ * String source = edge.source();
+ *
+ * String target = edge.target();
+ * }</pre>
+ *
+ * <p>Graph elements expose properties associated with
+ * vertices and relationships:</p>
+ *
+ * <pre>{@code
+ * Vertex vertex = ...
+ *
+ * Optional<String> name =
+ *         vertex.get("name");
+ * }</pre>
+ *
+ * <p>This model intentionally avoids introducing traversal
+ * APIs, graph query languages, path semantics, graph
+ * algorithms, or provider-specific navigation capabilities
+ * beyond the minimal lifecycle operations defined by the
+ * Communication API.</p>
+ *
+ * <p>The design supports extensibility to accommodate
+ * variations across graph databases, including capabilities
+ * such as typed relationships, distributed graph storage,
+ * graph partitioning, replication strategies,
+ * provider-specific metadata, or eventual consistency
+ * models.</p>
+ *
+ * <p>This model is part of the Jakarta NoSQL Communication API
+ * and follows its principles of optional adoption, minimal
+ * abstraction, extensibility, and preservation of native
+ * database semantics.</p>
+ *
+ * <p>In summary, the graph communication model defines a
+ * minimal, low-level, and extensible foundation for
+ * interacting with graph-oriented NoSQL systems while
+ * preserving their native operational characteristics.</p>
+ */
 package jakarta.nosql.communication.graph;

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -34,9 +34,7 @@
  *
  * manager.put(vertex);
  *
- * Optional<Vertex> result =
- *         manager.findVertexById("user:10");
- *
+ * Optional<Vertex> result = manager.findVertexById("user:10");
  * manager.deleteVertexById("user:10");
  * }</pre>
  *

--- a/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/graph/package-info.java
@@ -45,9 +45,7 @@
  * Edge edge = ...
  *
  * String type = edge.type();
- *
  * String source = edge.source();
- *
  * String target = edge.target();
  * }</pre>
  *

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -27,13 +27,6 @@
  * and removing data structures according to the semantics
  * of each NoSQL database model.</p>
  *
- * <p>The APIs defined in this package intentionally avoid
- * introducing query languages, traversal semantics,
- * aggregation models, relational abstractions,
- * transactional guarantees, or provider-specific behaviors
- * beyond the minimal communication contracts defined by
- * Jakarta NoSQL.</p>
- *
  * <p>The Communication API provides specialized communication
  * models aligned with the primary NoSQL database categories,
  * including key-value, column-family, document,

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -35,30 +35,9 @@
  * Jakarta NoSQL.</p>
  *
  * <p>The Communication API provides specialized communication
- * models aligned with the primary NoSQL database categories:</p>
- *
- * <ul>
- *     <li>Key-value databases</li>
- *     <li>Column-family databases</li>
- *     <li>Document databases</li>
- *     <li>Graph databases</li>
- * </ul>
- *
- * <p>The following example illustrates the interaction flow
- * using a communication manager:</p>
- *
- * <pre>{@code
- * BucketManagerFactory factory = ...
- *
- * BucketManager manager = factory.get("users");
- *
- * KeyValueRecord record = ...
- *
- * manager.put(record);
- *
- * Optional<KeyValueRecord> result =
- *         manager.findByKey("user:10");
- * }</pre>
+ * models aligned with the primary NoSQL database categories,
+ * including key-value, column-family, document,
+ * and graph databases.</p>
  *
  * <p>The Communication API is intentionally minimal and
  * designed to support extensibility according to the

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -27,18 +27,11 @@
  * and removing data structures according to the semantics
  * and capabilities of the target database.</p>
  *
- * <p>The APIs defined in this package intentionally avoid
- * introducing query languages, traversal semantics,
- * aggregation models, relational abstractions,
- * transactional guarantees, or provider-specific behaviors
- * beyond the minimal communication contracts defined by
- * Jakarta NoSQL.</p>
- *
- * <p>The Communication API is intentionally minimal and
- * designed to support extensibility according to the
- * capabilities, consistency models, serialization
- * strategies, and operational characteristics of the
- * underlying database implementation.</p>
+ * <p>The Communication API is intentionally designed to
+ * support extensibility according to the capabilities,
+ * consistency models, serialization strategies,
+ * and operational characteristics of the underlying
+ * database implementation.</p>
  *
  * <p>Depending on the provider implementation, communication
  * operations may support capabilities such as distributed

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -15,41 +15,73 @@
  */
 
 /**
+ * Provides the Communication API for Jakarta NoSQL.
  *
- * <p>The Communication API is an optional, lower-level API for interacting
- * directly with NoSQL databases. It provides a minimal and extensible contract
- * that enables integration between Jakarta NoSQL and vendor-specific drivers.</p>
+ * <p>The Communication API defines a minimal and extensible
+ * foundation for interacting with NoSQL databases while
+ * preserving the native semantics and operational behavior
+ * of the underlying database implementation.</p>
  *
- * <p>This API acts as an integration layer between the Mapping API and
- * underlying NoSQL database providers. Implementations may use this layer
- * to standardize communication, or they may integrate directly with the
- * Mapping API without using it.</p>
+ * <p>The Communication API focuses on low-level lifecycle
+ * operations such as storing, retrieving, replacing,
+ * and removing data structures according to the semantics
+ * of each NoSQL database model.</p>
  *
- * <p>The Communication API is intentionally minimal. It defines only the
- * essential abstractions required to represent operations and interact with
- * NoSQL systems, avoiding unnecessary constraints or assumptions about
- * database behavior.</p>
+ * <p>The APIs defined in this package intentionally avoid
+ * introducing query languages, traversal semantics,
+ * aggregation models, relational abstractions,
+ * transactional guarantees, or provider-specific behaviors
+ * beyond the minimal communication contracts defined by
+ * Jakarta NoSQL.</p>
  *
- * <p>This API is also designed for extensibility. NoSQL databases differ
- * significantly in their data models, capabilities, and execution semantics.
- * Implementations are expected to extend or adapt these abstractions to
- * support native features, preserving the specific behavior of each database.</p>
+ * <p>The Communication API provides specialized communication
+ * models aligned with the primary NoSQL database categories:</p>
  *
- * <p>The Communication API does not enforce a unified query language,
- * consistency model, or execution semantics. Instead, it provides a common
- * structure for interaction while allowing each provider to define the
- * meaning and execution of operations according to its capabilities.</p>
+ * <ul>
+ *     <li>Key-value databases</li>
+ *     <li>Column-family databases</li>
+ *     <li>Document databases</li>
+ *     <li>Graph databases</li>
+ * </ul>
  *
- * <p>This package defines a minimal set of abstractions whose support may
- * vary depending on the underlying database. Implementations may support
- * all, some, or none of the defined features.</p>
+ * <p>The following example illustrates the interaction flow
+ * using a communication manager:</p>
  *
- * <p>This API is primarily intended for database providers, framework
- * implementers, and integration layers. Application developers are expected
- * to use higher-level APIs, such as the Mapping API.</p>
+ * <pre>{@code
+ * BucketManagerFactory factory = ...
  *
- * <p>In summary, the Communication API provides an optional, minimal, and
- * extensible foundation for integrating Jakarta NoSQL with diverse NoSQL
- * systems, while preserving their native characteristics and behaviors.</p>
+ * BucketManager manager = factory.get("users");
+ *
+ * KeyValueRecord record = ...
+ *
+ * manager.put(record);
+ *
+ * Optional<KeyValueRecord> result =
+ *         manager.findByKey("user:10");
+ * }</pre>
+ *
+ * <p>The Communication API is intentionally minimal and
+ * designed to support extensibility according to the
+ * capabilities and characteristics of each database model
+ * and provider implementation.</p>
+ *
+ * <p>Depending on the provider implementation, communication
+ * operations may support capabilities such as distributed
+ * replication, eventual consistency, partitioning,
+ * provider-defined serialization strategies, batching
+ * optimizations, append-oriented persistence,
+ * graph connectivity semantics, or provider-specific
+ * communication behaviors.</p>
+ *
+ * <p>Providers may configure communication managers using
+ * mechanisms such as Java properties, environment variables,
+ * dependency injection, configuration files,
+ * provider-defined defaults, or provider-specific
+ * communication contexts.</p>
+ *
+ * <p>In summary, the Communication API defines a minimal,
+ * low-level, provider-neutral, and extensible foundation
+ * for integrating NoSQL communication models within
+ * Jakarta NoSQL.</p>
  */
 package jakarta.nosql.communication;

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -51,9 +51,5 @@
  * provider-defined defaults, or provider-specific
  * communication contexts.</p>
  *
- * <p>In summary, the Communication API defines a minimal,
- * low-level, provider-neutral, and extensible foundation
- * for integrating NoSQL communication models within
- * Jakarta NoSQL.</p>
  */
 package jakarta.nosql.communication;

--- a/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
+++ b/communication-api/src/main/java/jakarta/nosql/communication/package-info.java
@@ -25,24 +25,26 @@
  * <p>The Communication API focuses on low-level lifecycle
  * operations such as storing, retrieving, replacing,
  * and removing data structures according to the semantics
- * of each NoSQL database model.</p>
+ * and capabilities of the target database.</p>
  *
- * <p>The Communication API provides specialized communication
- * models aligned with the primary NoSQL database categories,
- * including key-value, column-family, document,
- * and graph databases.</p>
+ * <p>The APIs defined in this package intentionally avoid
+ * introducing query languages, traversal semantics,
+ * aggregation models, relational abstractions,
+ * transactional guarantees, or provider-specific behaviors
+ * beyond the minimal communication contracts defined by
+ * Jakarta NoSQL.</p>
  *
  * <p>The Communication API is intentionally minimal and
  * designed to support extensibility according to the
- * capabilities and characteristics of each database model
- * and provider implementation.</p>
+ * capabilities, consistency models, serialization
+ * strategies, and operational characteristics of the
+ * underlying database implementation.</p>
  *
  * <p>Depending on the provider implementation, communication
  * operations may support capabilities such as distributed
  * replication, eventual consistency, partitioning,
- * provider-defined serialization strategies, batching
- * optimizations, append-oriented persistence,
- * graph connectivity semantics, or provider-specific
+ * batching optimizations, append-oriented persistence,
+ * provider-defined metadata, or provider-specific
  * communication behaviors.</p>
  *
  * <p>Providers may configure communication managers using
@@ -51,5 +53,9 @@
  * provider-defined defaults, or provider-specific
  * communication contexts.</p>
  *
+ * <p>In summary, the Communication API defines a minimal,
+ * low-level, provider-neutral, and extensible foundation
+ * for integrating communication models within Jakarta
+ * NoSQL.</p>
  */
 package jakarta.nosql.communication;

--- a/communication-api/src/main/java/module-info.java
+++ b/communication-api/src/main/java/module-info.java
@@ -19,4 +19,8 @@
  */
 module jakarta.nosql.communication {
     exports jakarta.nosql.communication;
+    exports jakarta.nosql.communication.document;
+    exports jakarta.nosql.communication.keyvalue;
+    exports jakarta.nosql.communication.column;
+    exports jakarta.nosql.communication.graph;
 }

--- a/communication-api/src/main/java/module-info.java
+++ b/communication-api/src/main/java/module-info.java
@@ -15,7 +15,29 @@
  */
 
 /**
- * Defines the core communication API for NoSQL database operations.
+ * Defines the Jakarta NoSQL Communication API module.
+ *
+ * <p>This module provides a minimal and extensible
+ * communication foundation for interacting with NoSQL
+ * databases while preserving the native semantics and
+ * operational behavior of the underlying database
+ * implementation.</p>
+ *
+ * <p>The Communication API focuses on low-level lifecycle
+ * operations for storing, retrieving, replacing,
+ * and removing data structures according to the
+ * capabilities and characteristics of the target database.</p>
+ *
+ * <p>The APIs exposed by this module are designed to support
+ * extensibility, provider neutrality, and interoperability
+ * across different NoSQL communication models.</p>
+ *
+ * <p>Provider implementations may support capabilities such
+ * as distributed replication, eventual consistency,
+ * partitioning, batching optimizations,
+ * provider-defined serialization strategies,
+ * graph connectivity semantics, or provider-specific
+ * communication behaviors.</p>
  */
 module jakarta.nosql.communication {
     exports jakarta.nosql.communication;


### PR DESCRIPTION
This pull request introduces the new Communication API to Jakarta NoSQL, providing a minimal and extensible foundation for interacting with various NoSQL database models (key-value, document, column, and graph) while preserving native database semantics. The changes include comprehensive documentation updates, new API module exports, and detailed package-level descriptions for each communication model.

**Introduction of the Communication API:**

* Added the Communication API, which defines a minimal, extensible, and provider-neutral foundation for low-level operations (store, retrieve, replace, remove) across NoSQL databases, with an emphasis on extensibility and preservation of native database semantics. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93R24) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R204-R316) [[3]](diffhunk://#diff-61387882374d8f8b0667e3aad3b7b503bf77cf4d0ad3de96e134b43b2841419fL18-R52) [[4]](diffhunk://#diff-4bdd6f62fc6ba0c7985bfc15b8b1266d7ba71c57886ec8e9ff3c8304035bf8fdL18-R47)

**Documentation and Usage Examples:**

* Expanded the `README.adoc` with detailed explanations and code samples for the key-value, document, column, and graph communication models, illustrating how to interact with each NoSQL paradigm using the new API.
* Updated the changelog to reflect the introduction of the Communication API.

**API and Module Enhancements:**

* Enhanced the `module-info.java` to export new communication model packages (`document`, `keyvalue`, `column`, `graph`) and provided a detailed module-level description of the Communication API’s purpose and design principles.

**Package-Level Documentation:**

* Added comprehensive JavaDoc to the root `communication` package and each subpackage, clearly describing the intent, design, and extensibility of the Communication API, with specific focus on the graph communication model. [[1]](diffhunk://#diff-61387882374d8f8b0667e3aad3b7b503bf77cf4d0ad3de96e134b43b2841419fL18-R52) [[2]](diffhunk://#diff-a278bc89f0f398e47399864e4690b96af4906cfdaef267890e9379c4dd0ccc5bR17-R83)