### PR TITLE
Release 1 1 0 m3

### DIFF
--- a/COMMUNICATION.adoc
+++ b/COMMUNICATION.adoc
@@ -112,6 +112,6 @@ String target = edge.target();
 <dependency>
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql.communication-api</artifactId>
-    <version>1.1.0-M2</version>
+    <version>1.1.0-M3</version>
 </dependency>
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -201,7 +201,7 @@ Optional<BudgetCar> result = template.typedQuery("WHERE price < 100", BudgetCar.
 <dependency>
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql-api</artifactId>
-    <version>1.1.0-M2</version>
+    <version>1.1.0-M3</version>
 </dependency>
 ----
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M3</version>
     </parent>
 
     <artifactId>jakarta.nosql-api</artifactId>

--- a/communication-api/pom.xml
+++ b/communication-api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M3</version>
     </parent>
 
     <artifactId>jakarta.nosql.communication-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0-M3</version>
     <packaging>pom</packaging>
 
     <name>Jakarta NoSQL</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M3</version>
     </parent>
 
     <artifactId>jakarta.nosql-spec</artifactId>
@@ -95,7 +95,7 @@
     		<plugin>
     			<groupId>org.eclipse.m2e</groupId>
     			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.1.0-SNAPSHOT</version>
+    			<version>1.1.0-M3</version>
     			<configuration>
     				<lifecycleMappingMetadata>
     					<pluginExecutions>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0-M3</version>
     </parent>
 
     <artifactId>jakarta.nosql-tck</artifactId>


### PR DESCRIPTION
This pull request updates the project version from `1.1.0-SNAPSHOT` and `1.1.0-M2` to `1.1.0-M3` across all core modules, documentation, and dependencies. This ensures consistency throughout the build system and documentation, and aligns all modules with the latest milestone release.

Version updates across the project:

* Updated the parent version to `1.1.0-M3` in the main `pom.xml` and all module `pom.xml` files, including `api`, `communication-api`, `spec`, and `tck` modules. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L23-R23) [[2]](diffhunk://#diff-f35103f068e191d5d8933637b2d4217d8f90a78728ccab1bada951a8d1c83590L16-R16) [[3]](diffhunk://#diff-64ac9dc43be1aa2e1f1f417070fdc9c778b40969ac29ea79148e1d0133b01935L16-R16) [[4]](diffhunk://#diff-850091365acdcdf5a1023a8b65788ae4a0d22b78684c8b9a3c0207fe9e520627L18-R18) [[5]](diffhunk://#diff-c7973ae892437cdc63d039ee91cf6d93bc035ba2f77d5cfaf8c326924b6ffa2dL18-R18)
* Updated the `lifecycle-mapping` plugin version to `1.1.0-M3` in `spec/pom.xml`.

Documentation and dependency updates:

* Updated dependency versions in `README.adoc` and `COMMUNICATION.adoc` to reference `1.1.0-M3` for `jakarta.nosql-api` and `jakarta.nosql.communication-api`. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L204-R204) [[2]](diffhunk://#diff-737459a30942300fc1321acc263a50ac163b579b9b0d73adde8c62c434ea889cL115-R115)