### PR TITLE
Update snapshot

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-M3</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.nosql-api</artifactId>

--- a/communication-api/pom.xml
+++ b/communication-api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-M3</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.nosql.communication-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>jakarta.nosql</groupId>
     <artifactId>jakarta.nosql-parent</artifactId>
-    <version>1.1.0-M3</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta NoSQL</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-M3</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.nosql-spec</artifactId>
@@ -95,7 +95,7 @@
     		<plugin>
     			<groupId>org.eclipse.m2e</groupId>
     			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.1.0-M3</version>
+    			<version>1.1.0-SNAPSHOT</version>
     			<configuration>
     				<lifecycleMappingMetadata>
     					<pluginExecutions>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.nosql</groupId>
         <artifactId>jakarta.nosql-parent</artifactId>
-        <version>1.1.0-M3</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.nosql-tck</artifactId>


### PR DESCRIPTION
This pull request updates the project version from `1.1.0-M3` to `1.1.0-SNAPSHOT` across all Maven module `pom.xml` files. This change ensures that all modules are aligned to the latest snapshot version for ongoing development.

Version updates across modules:

* Updated the parent version to `1.1.0-SNAPSHOT` in the following `pom.xml` files:
  - `pom.xml`
  - `api/pom.xml`
  - `communication-api/pom.xml`
  - `spec/pom.xml`
  - `tck/pom.xml`

Build plugin version update:

* Updated the `org.eclipse.m2e:lifecycle-mapping` plugin version to `1.1.0-SNAPSHOT` in `spec/pom.xml` to match the new project version.