### PR TITLE
Update `spec.version` to refer to 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </developers>
 
     <properties>
-        <spec.version>1.0</spec.version>
+        <spec.version>1.1</spec.version>
         <apache.rat.version>0.15</apache.rat.version>
         <checkstyle.excludes></checkstyle.excludes>
         <jacoco.maven.version>0.8.14</jacoco.maven.version>


### PR DESCRIPTION
This helps for
- https://github.com/jakartaee/specifications/pull/912#discussion_r3414523192
> Shouldn't this say "v1.1"?

as it's used in 
https://github.com/jakartaee/nosql/blob/dd9caebeccb7804aedb21fc6cfd755a50d146799/api/pom.xml#L54

but it also influences manifest:
https://github.com/jakartaee/nosql/blob/dd9caebeccb7804aedb21fc6cfd755a50d146799/api/pom.xml#L80-L89

-----

There is second `spec.version` in https://github.com/jakartaee/nosql/blob/dd9caebeccb7804aedb21fc6cfd755a50d146799/spec/pom.xml#L30 - this results in https://github.com/jakartaee/specifications/pull/913#issue-4668587431:
>  files have 1.1.0-M3 embedded inside of them already.

I'm not touching it here. Separate issue.